### PR TITLE
strip potential trailing slash in BASE_URL

### DIFF
--- a/functions/auth/callback.js
+++ b/functions/auth/callback.js
@@ -26,7 +26,9 @@ export async function onRequest(context) {
     const responseData = await response.json();
     
     if (responseData.access_token) {
-      return Response.redirect(`${env.BASE_URL}/?access_token=${responseData.access_token}`, 302);
+      const redirectUrl = new URL(env.BASE_URL);
+      redirectUrl.searchParams.set('access_token', responseData.access_token);
+      return Response.redirect(redirectUrl, 302);
     } else {
       throw new Error('Access token not found');
     }


### PR DESCRIPTION
When copy/pasting the URL from cloudflare pages into the env variables, if the BASE_URL has a trailing slash the redirect will fail with a misleading "Access token not found" error. Formatting the URL programatically fixes this issue.