### PR TITLE
Add more file types/extensions based on https://developer.mozilla.org/en-US/docs

### DIFF
--- a/src/components/FileBrowser.vue
+++ b/src/components/FileBrowser.vue
@@ -196,11 +196,11 @@ import Upload from '@/components/file/Upload.vue';
 
 // Categories for filtering
 const extensionCategories = {
-  image: ['jpg', 'jpeg', 'png', 'gif', 'svg', 'bmp', 'tif', 'tiff'],
+  image: ['jpg', 'jpeg', 'png', 'apng', 'webp', 'avif', 'ico', 'cur', 'gif', 'svg', 'bmp', 'tif', 'tiff'],
   document: ['pdf', 'doc', 'docx', 'ppt', 'pptx', 'vxls', 'xlsx', 'txt', 'rtf'],
-  video: ['mp4', 'avi', 'mov', 'wmv', 'flv'],
-  audio: ['mp3', 'wav', 'aac', 'ogg', 'flac'],
-  compressed: ['zip', 'rar', '7z', 'tar', 'gz', 'tgz']
+  video: ['mp4', 'avi', 'mov', 'wmv', 'flv', 'mpeg', 'webm', 'ogv', 'ts', '3gp', '3g2'],
+  audio: ['mp3', 'wav', 'aac', 'ogg', 'flac', 'weba', 'oga', 'opus', 'mid', 'midi', '3gp', '3g2'],
+  compressed: ['zip', 'rar', '7z', 'tar', 'gz', 'tgz', 'bz', 'bz2']
 }
 
 const route = useRoute();

--- a/src/components/file/TipTap.vue
+++ b/src/components/file/TipTap.vue
@@ -350,7 +350,7 @@ const editor = useEditor({
     handleDrop: async function(view, event, slice, moved) {
       if (!moved && event.dataTransfer && event.dataTransfer.files && event.dataTransfer.files.length) {
         const files = Array.from(event.dataTransfer.files);
-        const allowedTypes = ['image/jpeg', 'image/png', 'image/gif', 'image/svg+xml', 'image/bmp', 'image/tif', 'image/tiff'];
+        const allowedTypes = ['image/jpeg', 'image/png', 'image/webp', 'image/apng', 'image/avif', 'image/gif', 'image/svg+xml', 'image/x-icon', 'image/bmp', 'image/tif', 'image/tiff'];
         const { schema } = view.state;
         const coordinates = view.posAtCoords({ left: event.clientX, top: event.clientY });
         let position = coordinates.pos;
@@ -367,7 +367,7 @@ const editor = useEditor({
               }
             }
           } else {
-            notifications.notify('Only images can be uploaded (JPEG, PNG, GIF, SVG, TIFF and BMP).', 'error');
+            notifications.notify('Only images can be uploaded (JPEG, PNG, WEBP, APNG, AVIF, GIF, SVG, ICO, TIFF and BMP).', 'error');
           }
         }
         return true;


### PR DESCRIPTION
I noticed that some very common file formats were missing, in my case I saw that webp images had no thumbnail in the file browser.
I added some file extensions based on https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types.

Audio and video now have 2 duplicate file extension, namely '3gp' and '3g2' this affects the sorting based on category, where only the first occurring category, here 'video' is considered due to the use of find(). But this should be fine. Having it in both matters for filtering based on category.