### PR TITLE
fix: add defaultBranch to branch list and refactor

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,0 +1,21 @@
+import axios from "axios";
+import { ref } from "vue";
+
+const token = ref(localStorage.getItem("token") || null);
+
+export const githubApiGet = async (url, additionalParams) => {
+  try {
+    const response = await axios.get(url, {
+      params: {
+        timestamp: Date.now(),
+        ...(additionalParams && additionalParams)
+      },
+      headers: {
+        Authorization: `Bearer ${token.value}`,
+      },
+    });
+    return response.data;
+  } catch (error) {
+    throw error;
+  }
+};

--- a/src/views/RepoView.vue
+++ b/src/views/RepoView.vue
@@ -221,7 +221,7 @@ const setRepo = async () => {
   }
 
   // We retrieve the list of branches
-  const repoBranches = await github.getBranches(repoStore.owner, props.repo);
+  const repoBranches = await github.getBranches(repoStore.owner, props.repo, repoDetails.default_branch);
   branches.value = repoBranches;
 
   if (repoBranches.length === 0) {


### PR DESCRIPTION
The call for the https://api.github.com/repos/<owner>/<repo>/branches return 30 results and if the repo has a lot of branches like dependabot, the default branch could not be on the list

As we get the name of the default branch from the repo data, I added it on the begin of the list, and increase the branch list api call to return 100 branches

And create a utils that can be use to replace the same axios.get code