### PR TITLE
Show the filebrowser at a reasonable width on small screens

### DIFF
--- a/src/styles/filebrowser.css
+++ b/src/styles/filebrowser.css
@@ -123,8 +123,10 @@
 
 /* File browser modal */
 
-.modal-file-browser .modal-box {
-  @apply w-[calc(100vw-14rem)];
+@media (min-width: theme('screens.md')) {
+  .modal-file-browser .modal-box {
+    @apply w-[calc(100vw-20rem)];
+  }
 }
 
 .modal-body .fb-files {


### PR DESCRIPTION
before:

<img width="300" alt="image" src="https://github.com/pages-cms/pages-cms/assets/921605/94c03add-446d-48d8-85d3-f6d41076bb90">

after:

<img width="300" alt="SCR-20240619-ixln" src="https://github.com/pages-cms/pages-cms/assets/921605/632e98ff-3ff2-4966-9616-39827a6f211e">
