### PR TITLE
docs(README): add community section

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ To get a local version up and running:
 
 Cloudflare has very generous free tiers and can also host your actual website. It's a great alternative to GitHub Pages, Netlify or Vercel.
 
+## Community
+- [Nuxt Pages CMS](https://github.com/StevenJPx2/nuxt-pagescms) - A [Nuxt](https://nuxt.com) integration for Pages CMS. It allows for a type-safe, zero config setup for composables that call your content.
+
 ## License
 
 Everything in this repo is released under the [MIT License](LICENSE).


### PR DESCRIPTION
Hey there!

I wanna first thank you for this awesome CMS! I use this with all of my smaller clients that need a simple marketing website, and this works great! 
However when I was using it, I increasingly started coding my own integrations for this in Nuxt until I decided that this needs its own module. 😄

[Nuxt Pages CMS](https://github.com/StevenJPx2/nuxt-pagescms) scans your `.pages.yml` and then generates the types for you without any configuration, and then you can use the composables `usePagesFile` or `usePagesCollection` anywhere in your code, and it will be type safe in every possible area of your code.

I've tested in multiple client websites to the point where I feel satisfied to raise a PR for this.

So in this PR, I've just added a community section that highlights this module and other modules to come!