### PR TITLE
Feature/Add i18n Content Management

### DIFF
--- a/src/components/file/Delete.vue
+++ b/src/components/file/Delete.vue
@@ -20,9 +20,10 @@
 </template>
 
 <script setup>
-import { ref } from 'vue';
+import { ref, inject } from 'vue';
 import notifications from '@/services/notifications';
 import github from '@/services/github';
+import i18n from '@/services/i18n';
 import Modal from '@/components/utils/Modal.vue';
 
 const emits = defineEmits(['file-deleted', 'error']);
@@ -37,6 +38,7 @@ const props = defineProps({
 
 const deleteModal = ref(null);
 const status = ref('');
+const repoStore = inject('repoStore', { owner: null, repo: null, branch: null, config: null, details: null });
 
 const deleteEntry = async () => {
   status.value = 'deleting';
@@ -47,6 +49,7 @@ const deleteEntry = async () => {
     emits('file-deleted', props.path);
     notifications.notify(`"${props.path}" was deleted.`, 'success');
     deleteModal.value.closeModal();
+    await i18n.deleteLocaleFiles(props.path, props, repoStore);
   }
   status.value = '';
 };

--- a/src/components/file/Editor.vue
+++ b/src/components/file/Editor.vue
@@ -161,6 +161,7 @@ import notifications from '@/services/notifications';
 import github from '@/services/github';
 import config from '@/services/config';
 import serialization from '@/services/serialization';
+import i18n from '@/services/i18n';
 import useSchema from '@/composables/useSchema';
 import CodeMirror from '@/components/file/CodeMirror.vue';
 import Datagrid from '@/components/file/Datagrid.vue';
@@ -442,6 +443,7 @@ const save = async () => {
       // We've updated the configuration, we need to reload it
       await config.set(repoStore.owner, repoStore.repo, repoStore.branch);
     }
+    await i18n.saveLocaleFiles(model.value, currentPath.value, mode.value, props, repoStore);
     status.value = '';
   } catch (error) {
     notifications.notify(`Failed to save the file "${currentPath.value}"`, 'error');

--- a/src/components/file/Rename.vue
+++ b/src/components/file/Rename.vue
@@ -20,9 +20,10 @@
 </template>
 
 <script setup>
-import { onMounted, ref, watch } from 'vue';
+import { onMounted, ref, watch, inject } from 'vue';
 import notifications from '@/services/notifications';
 import github from '@/services/github';
+import i18n from '@/services/i18n';
 import Modal from '@/components/utils/Modal.vue';
 
 const emits = defineEmits(['file-renamed']);
@@ -37,6 +38,7 @@ const props = defineProps({
 const renameModal = ref(null);
 const newPath = ref('');
 const status = ref('');
+const repoStore = inject('repoStore', { owner: null, repo: null, branch: null, config: null, details: null });
 
 const renameEntry = async () => {
   status.value = 'renaming';
@@ -47,6 +49,7 @@ const renameEntry = async () => {
     emits('file-renamed', { renamedPath: newPath.value, renamedSha: newSha });
     notifications.notify(`File "${props.path}" renamed to "${newPath.value}".`, 'success');
     renameModal.value.closeModal();
+    await i18n.renameLocaleFiles(props.path, newPath.value, props, repoStore);
   }
   status.value = '';
 };

--- a/src/services/i18n.js
+++ b/src/services/i18n.js
@@ -1,0 +1,223 @@
+import { Base64 } from "js-base64";
+import github from "@/services/github";
+import serialization from "@/services/serialization";
+import useSchema from "@/composables/useSchema";
+
+const { getSchemaByPath, sanitizeObject } = useSchema();
+const serializedTypes = ['yaml-frontmatter', 'json-frontmatter', 'toml-frontmatter', 'yaml', 'json', 'toml'];
+
+/**
+ * Function to strip the content root from a given path.
+ * Removes the content root prefix if it exists in the path.
+ */
+const stripContentRoot = (contentRoot, path) => {
+  return contentRoot && path.startsWith(contentRoot)
+    ? path.slice(contentRoot.length).replace(/^\//, "")
+    : path;
+};
+
+/**
+ * Save locale-specific files based on the content model, current path, and configuration.
+ * Handles creating, updating, and deleting locale files depending on the `published` status.
+ */
+const saveLocaleFiles = async (model, currentPath, mode, props, repoStore) => {
+  const config = repoStore?.config?.document;
+  if (!config || !config.i18n?.locales || config.i18n.locales.length === 0)
+    return;
+
+  const schema = getSchemaByPath(config, currentPath);
+  if (!schema) return;
+
+  const contentRoot = schema.path ? schema.path.replace(/^\/|\/$/g, "") : "";
+  const relativePath = stripContentRoot(contentRoot, currentPath);
+
+  const publishControl = config.i18n?.publish_control || false;
+  const isPublished = model?.published ?? true;
+
+  // Delete locale files if content is unpublished
+  if (publishControl && !isPublished) {
+    await deleteLocaleFiles(currentPath, props, repoStore);
+    return;
+  }
+
+  // Extract fields into shared and localized categories
+  const { sharedFields, localizedFields } = extractFieldsByLocale(
+    model,
+    config.i18n.locales
+  );
+
+  for (const { name: locale, path: basePath } of config.i18n.locales) {
+    const localeFilePath = `${basePath}${relativePath}`;
+
+    // Fetch existing file SHA if it exists
+    let localeFileSha = null;
+    try {
+      const localeFileData = await github.getFile(
+        props.owner,
+        props.repo,
+        props.branch,
+        localeFilePath
+      );
+      localeFileSha = localeFileData?.sha || null;
+    } catch (error) {
+      if (error.response?.status !== 404) throw error;
+    }
+
+    // Generate content for the locale file
+    const localeContent = generateLocaleContent(
+      sharedFields,
+      localizedFields[locale] || {},
+      schema,
+      mode
+    );
+
+    // Save the file with the generated content
+    await github.saveFile(
+      props.owner,
+      props.repo,
+      props.branch,
+      localeFilePath,
+      Base64.encode(localeContent),
+      localeFileSha,
+      true
+    );
+  }
+};
+
+/**
+ * Extracts fields into shared and localized categories based on locale suffixes.
+ * Returns an object containing shared fields and fields localized per locale.
+ */
+function extractFieldsByLocale(model, locales) {
+  const sharedFields = {};
+  const localizedFields = {};
+
+  Object.keys(model).forEach((key) => {
+    const localeSuffix = locales.find((localeConfig) =>
+      key.endsWith(`_${localeConfig.name}`)
+    );
+    if (localeSuffix) {
+      const fieldName = key.replace(`_${localeSuffix.name}`, "");
+      localizedFields[localeSuffix.name] = {
+        ...localizedFields[localeSuffix.name],
+        [fieldName]: model[key],
+      };
+    } else {
+      sharedFields[key] = model[key];
+    }
+  });
+
+  return { sharedFields, localizedFields };
+}
+
+/**
+ * Generates content for locale-specific files using serialization.
+ * Converts the content into the appropriate format based on the schema.
+ */
+function generateLocaleContent(sharedFields, localizedFields, schema, mode) {
+  let localeContent = "";
+
+  if (serializedTypes.includes(mode) && schema.fields) {
+    let localeContentObject = sanitizeObject({
+      ...sharedFields,
+      ...localizedFields,
+    });
+
+    if (["yaml", "json", "toml"].includes(mode) && schema.list) {
+      localeContentObject = localeContentObject.listWrapper;
+    }
+
+    localeContent = serialization.stringify(localeContentObject, {
+      format: mode,
+      delimiters: schema.delimiters,
+    });
+  } else {
+    localeContent = localizedFields.body || "";
+  }
+
+  return localeContent;
+}
+
+/**
+ * Rename locale-specific files when the main content file is renamed.
+ */
+const renameLocaleFiles = async (oldPath, newPath, props, repoStore) => {
+  const config = repoStore.config?.document;
+  if (!config || !config.i18n?.locales) return;
+
+  const schema = getSchemaByPath(config, oldPath);
+  if (!schema) return;
+
+  const contentRoot = schema.path ? schema.path.replace(/^\/|\/$/g, "") : "";
+  const relativeOldPath = stripContentRoot(contentRoot, oldPath);
+  const relativeNewPath = stripContentRoot(contentRoot, newPath);
+
+  for (const { name: locale, path: basePath } of config.i18n.locales) {
+    const localeFileOldPath = `${basePath}${relativeOldPath}`;
+    const localeFileNewPath = `${basePath}${relativeNewPath}`;
+
+    try {
+      const localeFileData = await github.getFile(
+        props.owner,
+        props.repo,
+        props.branch,
+        localeFileOldPath
+      );
+      if (localeFileData?.sha) {
+        await github.renameFile(
+          props.owner,
+          props.repo,
+          props.branch,
+          localeFileOldPath,
+          localeFileNewPath
+        );
+      }
+    } catch (error) {
+      if (error.response?.status !== 404) throw error;
+    }
+  }
+};
+
+/**
+ * Delete locale-specific files when the main content file is deleted.
+ */
+const deleteLocaleFiles = async (filePath, props, repoStore) => {
+  const config = repoStore.config?.document;
+  if (!config || !config.i18n?.locales) return;
+
+  const schema = getSchemaByPath(config, filePath);
+  if (!schema) return;
+
+  const contentRoot = schema.path ? schema.path.replace(/^\/|\/$/g, "") : "";
+  const relativePath = stripContentRoot(contentRoot, filePath);
+
+  for (const { name: locale, path: basePath } of config.i18n.locales) {
+    const localeFilePath = `${basePath}${relativePath}`;
+
+    try {
+      const localeFileData = await github.getFile(
+        props.owner,
+        props.repo,
+        props.branch,
+        localeFilePath
+      );
+      if (localeFileData?.sha) {
+        await github.deleteFile(
+          props.owner,
+          props.repo,
+          props.branch,
+          localeFilePath,
+          localeFileData.sha
+        );
+      }
+    } catch (error) {
+      if (error.response?.status !== 404) throw error;
+    }
+  }
+};
+
+export default {
+  saveLocaleFiles,
+  renameLocaleFiles,
+  deleteLocaleFiles,
+};


### PR DESCRIPTION
### **Overview**
This pull request introduces an **i18n Content Management** feature to Pages CMS. The feature streamlines the handling of locale-specific files, supporting efficient saving, renaming, and deletion based on configurations defined in `.pages.yml`.

### **Why This Feature?**
Most popular markdown site generators, such as **Docusaurus** and **Nextra**, follow a structured approach for Internationalization (i18n). They require content for each language to be stored in its own directory, and secondary language files depend on the presence of default language content. 

To align with these platforms, this feature ensures that content creators can efficiently manage locale-specific files without causing inconsistencies or missing translations. It also introduces a flexible **publish control** option for handling the publication status of localized content.

### **Details of the Feature**

#### 1. **Locale-Specific File Handling**
   - Automatically creates, renames, or deletes locale-specific files based on the content defined in `.pages.yml`.
   - Supports saving locale files when the main content file is saved.
   - Adds an optional `publish_control` setting to control the publication of locale files based on a `published` field.

#### 2. **Configuration Enhancements in `.pages.yml`**
The `.pages.yml` file has been extended to include i18n support. Below is an example configuration:

```yaml
i18n:
  locales:
    - name: "en"
      path: "pages/en/"
    - name: "ar"
      path: "pages/ar/"
  publish_control: true  # Optional - Enables publish control
```

- **Explanation**:
  - `locales`: Defines the list of supported locales, each with its corresponding path.
  - `publish_control`: Controls whether locale files should be created or deleted based on the `published` status of the main file. If not defined, it defaults to `false`.

#### 3. **Content Fields: Common vs. Locale-Specific**
   - **Common Fields**: Fields without a locale suffix (e.g., `title`, `description`) are shared across all locale files.
   - **Locale-Specific Fields**: Fields with a suffix (e.g., `title_en`, `description_ar`) are specific to the corresponding locale.

#### **Example of Content Structure in `.pages.yml`**
```yaml
content:
  - name: docs
    label: Documentation
    type: collection
    path: documentation
    filename: '{primary}.mdx'
    fields:
      - name: published
        label: Publish Status
        type: boolean
        required: true
        default: true
      - name: title_en
        label: Title (English)
        type: string
        required: true
      - name: title_ar
        label: Title (Arabic)
        type: string
        required: true
      - name: description_en
        label: Description (English)
        type: text
        required: true
      - name: description_ar
        label: Description (Arabic)
        type: text
        required: true
      - name: body
        label: Body Content
        type: rich-text
        required: true
```

### **Example Workflow and Output**

1. **Saving the Main Content File**
   - **Input Content**:
     ```yaml
     published: true
     title_en: "Hello World"
     title_ar: "مرحبا بالعالم"
     description_en: "This is an English description."
     description_ar: "هذا وصف باللغة العربية."
     body: "This is the shared content for all languages."
     ```
   - **Resulting Files**:
     - `pages/en/hello-world.mdx`
       ```yaml
       ---
       published: true
       title: "Hello World"
       description: "This is an English description."
       body: "This is the shared content for all languages."
       ---
       ```
     - `pages/ar/hello-world.mdx`
       ```yaml
       ---
       published: true
       title: "مرحبا بالعالم"
       description: "هذا وصف باللغة العربية."
       body: "This is the shared content for all languages."
       ---
       ```

2. **Scenario with `publish_control` Enabled**
   - If `published` is set to `false`:
     - Locale-specific files `pages/en/hello-world.mdx` and `pages/ar/hello-world.mdx` will be **deleted** automatically.
   - If `publish_control` is not defined or set to `false`, locale files are **not deleted** even if `published` is set to `false`.

3. **Renaming the Main Content**
   - When the main file is renamed, associated locale files are also renamed to match the new path.

4. **Deleting the Main Content**
   - Deleting the main content will automatically delete all related locale-specific files.

### **Use Case Scenarios**
- **Automatic Locale Management**: Content creators can save a primary content file, and locale-specific files will be automatically generated based on configured locales.
- **Publish Control (Optional)**: If `publish_control` is enabled, setting `published` to `false` removes all associated locale files, keeping drafts hidden from public view.

### **Backward Compatibility**
- The feature is fully backward compatible. If `i18n` or `publish_control` is not set, the system defaults to the previous behavior, ensuring no disruption to existing setups.
