### PR TITLE
Add support for polymorphic list composition

### DIFF
--- a/app/api/[owner]/[repo]/[branch]/entries/[path]/route.ts
+++ b/app/api/[owner]/[repo]/[branch]/entries/[path]/route.ts
@@ -117,6 +117,7 @@ const parseContent = (
             : value;
         }
       );
+
       if (schema.list) contentObject = contentObject.listWrapper;
     } catch (error: any) {
       throw new Error(`Error parsing frontmatter: ${error.message}`);

--- a/components/entry/entry-editor.tsx
+++ b/components/entry/entry-editor.tsx
@@ -49,7 +49,7 @@ export function EntryEditor({
   
   const { config } = useConfig();
   if (!config) throw new Error(`Configuration not found.`);
-  
+
   let schema = useMemo(() => {
     if (!name) return;
     return getSchemaByName(config?.object, name)

--- a/components/entry/entry-form.tsx
+++ b/components/entry/entry-form.tsx
@@ -123,6 +123,11 @@ const ListField = ({
 
   useEffect(() => {
     const defaultEntry = getDefaultValue(field);
+
+    if (typeof defaultEntry === "object" && Object.keys(defaultEntry).length === 0) {
+      return;
+    }
+
     if (arrayFields.length === 0 && !hasAppended.current && defaultEntry) {
       append(defaultEntry);
       hasAppended.current = true;
@@ -272,21 +277,25 @@ const renderSingleField = (
       name={fieldName}
       key={fieldName}
       control={control}
-      render={({ field: fieldProps }) => (
-        <FormItem>
-          {showLabel && field.label !== false &&
-            <FormLabel className="h-5">
-              {field.label || field.name}
-            </FormLabel>
-          }
-          {field.required && <span className="ml-2 rounded-md bg-muted px-2 py-0.5 text-xs font-medium">Required</span>}
-          <FormControl>
-            <FieldComponent {...fieldProps} field={field} />
-          </FormControl>
-          {field.description && <FormDescription>{field.description}</FormDescription>}
-          <FormMessage />
-        </FormItem>
-      )}
+      render={({ field: fieldProps }) => {
+        console.log(fieldProps);
+
+        return (
+          <FormItem>
+            {showLabel && field.label !== false &&
+              <FormLabel className="h-5">
+                {field.label || field.name}
+              </FormLabel>
+            }
+            {field.required && <span className="ml-2 rounded-md bg-muted px-2 py-0.5 text-xs font-medium">Required</span>}
+            <FormControl>
+              <FieldComponent {...fieldProps} field={field} />
+            </FormControl>
+            {field.description && <FormDescription>{field.description}</FormDescription>}
+            <FormMessage />
+          </FormItem>
+        );
+      }}
     />
   );
 };
@@ -317,7 +326,7 @@ const EntryForm = ({
   }, [fields]);
 
   const defaultValues = useMemo(() => {
-    return initializeState(fields, sanitizeObject(contentObject), true, true);
+    return initializeState(fields, sanitizeObject(contentObject), true);
   }, [fields, contentObject]);
 
   const form = useForm({

--- a/components/entry/entry-form.tsx
+++ b/components/entry/entry-form.tsx
@@ -44,7 +44,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import {
-  DndContext, 
+  DndContext,
   closestCenter,
   KeyboardSensor,
   PointerSensor,
@@ -89,9 +89,9 @@ const SortableItem = ({
   };
 
   return (
-    <div ref={setNodeRef} className={cn("bg-background flex gap-x-1 rounded-lg border items-center", type === "object" ? "px-2 py-4" : "px-1 py-2", isDragging ? "z-50" : "z-10" )} style={style}>
+    <div ref={setNodeRef} className={cn("bg-background flex gap-x-1 rounded-lg border items-center", type === "object" ? "px-2 py-4" : "px-1 py-2", isDragging ? "z-50" : "z-10")} style={style}>
       <Button type="button" variant="ghost" size="icon-sm" className="h-8 cursor-move" {...attributes} {...listeners}>
-        <GripVertical className="h-4 w-4"/>
+        <GripVertical className="h-4 w-4" />
       </Button>
       {children}
     </div>
@@ -122,8 +122,9 @@ const ListField = ({
   const hasAppended = useRef(false);
 
   useEffect(() => {
-    if (arrayFields.length === 0 && !hasAppended.current) {
-      append(getDefaultValue(field));
+    const defaultEntry = getDefaultValue(field);
+    if (arrayFields.length === 0 && !hasAppended.current && defaultEntry) {
+      append(defaultEntry);
       hasAppended.current = true;
     }
   }, [arrayFields, append, field]);
@@ -171,7 +172,7 @@ const ListField = ({
                     <div className="grid gap-6 flex-1">
                       {field.type === "object" && field.fields
                         ? renderFields(field.fields, `${fieldName}.${index}`)
-                        : field.types !== undefined ? 
+                        : field.types !== undefined ?
                           (() => {
                             const type = (arrayField as any).type;
                             const nestedConfig = field.types.find(t => t.name === type);
@@ -187,8 +188,8 @@ const ListField = ({
                                 .filter((field): field is Field => field !== null)
                             }], `${fieldName}.${index}`)
                           })()
-                        :
-                        renderSingleField(field, `${fieldName}.${index}`, control, false)
+                          :
+                          renderSingleField(field, `${fieldName}.${index}`, control, false)
                       }
                     </div>
                     <Tooltip>
@@ -234,7 +235,7 @@ const ListField = ({
                     ))}
                   </DropdownMenuContent>
                 </DropdownMenu>
-              : <Button
+                : <Button
                   type="button"
                   variant="outline"
                   size="sm"
@@ -251,7 +252,7 @@ const ListField = ({
                 </Button>
             }
           </div>
-          <FormMessage/>
+          <FormMessage />
         </FormItem>
       )}
     />
@@ -283,7 +284,7 @@ const renderSingleField = (
             <FieldComponent {...fieldProps} field={field} />
           </FormControl>
           {field.description && <FormDescription>{field.description}</FormDescription>}
-          <FormMessage/>
+          <FormMessage />
         </FormItem>
       )}
     />
@@ -323,7 +324,7 @@ const EntryForm = ({
     resolver: zodSchema && zodResolver(zodSchema),
     defaultValues,
   });
-  
+
   const { isDirty } = useFormState({
     control: form.control
   });
@@ -332,7 +333,7 @@ const EntryForm = ({
   const renderFields = (fields: Field[], parentName?: string) => {
     return fields.map((field) => {
       if (field.hidden) return null;
-      
+
       const fieldName = parentName ? field.name ? `${parentName}.${field.name}` : parentName : field.name;
 
       if (field.types) {
@@ -380,17 +381,17 @@ const EntryForm = ({
                   className={cn(buttonVariants({ variant: "outline", size: "icon-xs" }), "mr-4 shrink-0")}
                   href={navigateBack}
                 >
-                  <ChevronLeft className="h-4 w-4"/>
+                  <ChevronLeft className="h-4 w-4" />
                 </Link>
               }
-              
+
               <h1 className="font-semibold text-lg md:text-2xl truncate">{title}</h1>
             </header>
             <div onSubmit={form.handleSubmit(handleSubmit)} className="grid items-start gap-6">
               {renderFields(fields)}
             </div>
           </div>
-          
+
           <div className="hidden lg:block w-64">
             <div className="flex flex-col gap-y-4 sticky top-0">
               <div className="flex gap-x-2">
@@ -400,11 +401,11 @@ const EntryForm = ({
                 </Button>
                 {options ? options : null}
               </div>
-              {path && history && <EntryHistoryBlock history={history} path={path}/>}
+              {path && history && <EntryHistoryBlock history={history} path={path} />}
             </div>
           </div>
           <div className="lg:hidden fixed top-0 right-0 h-14 flex items-center gap-x-2 z-10 pr-4 md:pr-6">
-            {path && history && <EntryHistoryDropdown history={history} path={path}/>}
+            {path && history && <EntryHistoryDropdown history={history} path={path} />}
             <Button type="submit" disabled={isSubmitting}>
               Save
               {isSubmitting && (<Loader className="ml-2 h-4 w-4 animate-spin" />)}

--- a/components/entry/entry-form.tsx
+++ b/components/entry/entry-form.tsx
@@ -255,21 +255,6 @@ const ListField = ({
                   <Plus className="h-4 w-4" />
                   Add an entry
                 </Button>
-              : <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              onClick={() => {
-                append(field.type === "object"
-                  ? initializeState(field.fields, {}, true)
-                  : getDefaultValue(field)
-                );
-              }}
-              className="gap-x-2"
-            >
-              <Plus className="h-4 w-4" />
-              Add an entry
-            </Button>
             }
           </div>
           <FormMessage />

--- a/components/entry/entry-form.tsx
+++ b/components/entry/entry-form.tsx
@@ -173,16 +173,18 @@ const ListField = ({
                         ? renderFields(field.fields, `${fieldName}.${index}`)
                         : field.types !== undefined ? 
                           (() => {
-                            const nestedConfig = field.types.find(t => t.name === arrayField.type);
+                            const type = (arrayField as any).type;
+                            const nestedConfig = field.types.find(t => t.name === type);
 
                             return renderFields([{
                               type: 'object',
-                              name: nestedConfig?.label || arrayField.type,
-                              poly: true,
-                              fields: Object.keys(arrayField).map((key) => {
-                                const nestedField = nestedConfig?.fields.find(f => f.name === key);
-                                return nestedField;
-                              }).filter(Boolean)
+                              name: '',
+                              fields: Object.keys(arrayField)
+                                .map((key) => {
+                                  const nestedField = nestedConfig?.fields.find(f => f.name === key);
+                                  return nestedField || null;
+                                })
+                                .filter((field): field is Field => field !== null)
                             }], `${fieldName}.${index}`)
                           })()
                         :
@@ -321,7 +323,7 @@ const EntryForm = ({
     resolver: zodSchema && zodResolver(zodSchema),
     defaultValues,
   });
-
+  
   const { isDirty } = useFormState({
     control: form.control
   });
@@ -331,7 +333,7 @@ const EntryForm = ({
     return fields.map((field) => {
       if (field.hidden) return null;
       
-      const fieldName = field.poly ? parentName : parentName ? `${parentName}.${field.name}` : field.name;
+      const fieldName = parentName ? field.name ? `${parentName}.${field.name}` : parentName : field.name;
 
       if (field.types) {
         return <ListField key={fieldName} control={form.control} field={field} fieldName={fieldName} renderFields={renderFields} />;

--- a/lib/configSchema.ts
+++ b/lib/configSchema.ts
@@ -63,6 +63,9 @@ const FieldObjectSchema: z.ZodType<any> = z.lazy(() => z.object({
       message: "'list' must be either a boolean or an object with 'min' and 'max' properties."
     }).strict()
   ]).optional(),
+  types: z.array({
+    message: "'types' must be an array."
+  }).optional(),
   hidden: z.boolean({
     message: "'hidden' must be a boolean."
   }).optional().nullable(),

--- a/lib/configSchema.ts
+++ b/lib/configSchema.ts
@@ -63,9 +63,6 @@ const FieldObjectSchema: z.ZodType<any> = z.lazy(() => z.object({
       message: "'list' must be either a boolean or an object with 'min' and 'max' properties."
     }).strict()
   ]).optional(),
-  types: z.array({
-    message: "'types' must be an array."
-  }).optional(),
   hidden: z.boolean({
     message: "'hidden' must be a boolean."
   }).optional().nullable(),
@@ -89,6 +86,23 @@ const FieldObjectSchema: z.ZodType<any> = z.lazy(() => z.object({
     }).strict()
   ]).optional(),
   options: z.object({}).optional().nullable(),
+  fields: z.array(z.lazy(() => FieldObjectSchema)).optional(),
+  types: z.array(z.lazy(() => TypeObjectSchema)).optional(),
+}).strict());
+
+const TypeObjectSchema: z.ZodType<any> = z.lazy(() => z.object({
+  name: z.string({
+    required_error: "'name' is required.",
+    invalid_type_error: "'name' must be a string.",
+  }).regex(/^[a-zA-Z0-9-_]+$/, {
+    message: "'name' must be alphanumeric with dashes and underscores.",
+  }),
+  label: z.union([
+    z.literal(false),
+    z.string({
+      message: "'label' must be a string or 'false'."
+    })
+  ]).optional(),
   fields: z.array(z.lazy(() => FieldObjectSchema)).optional(),
 }).strict());
 

--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -67,7 +67,7 @@ const initializeState = (
     if (value === undefined) {
       appliedValue = field.list && addDefaultEntryToLists ? [getDefaultValue(field)] : getDefaultValue(field);
     }
-    if (field.list && nestArrays) appliedValue = { value: appliedValue}
+    if ((field.list && nestArrays) || field.types?.length) appliedValue = { value: appliedValue}
     return appliedValue;
   });
 };

--- a/types/field.ts
+++ b/types/field.ts
@@ -10,4 +10,5 @@ export type Field = {
   pattern?: string | { regex: string; message?: string };
   options?: Record<string, unknown> | null;
   fields?: Field[];
+  types?: { name: string; label?: string; fields: Field[] }[];
 };


### PR DESCRIPTION
This addition allows list types to be polymorphic, to support this sort of config:

```yml
media:
  input: src/uploads
  output: /uploads
content:
  - name: pages
    label: Pages
    path: src
    type: collection
    filename: "{primary}/index.md"
    exclude: []
    filters:
      - name: layout
        value: layouts/page.njk
    fields:
      - name: layout
        type: string
        hidden: true
        default: layouts/page.njk
      - name: title
        type: string
        label: Title
      - name: blocks
        list: true
        label: Blocks
        type: object
        types:
          - name: hero
            label: Hero
            type: object
            fields:
              - name: eyebrow
                type: string
                label: Eyebrow
                required: false
              - name: title
                type: string
                label: Title
              - name: content
                type: markdown
                label: Content
              - name: background
                type: image
                label: Background
                required: false
          - name: text
            label: Text
            type: object
            fields:
              - name: title
                type: string
                label: Title
              - name: content
                type: markdown
                label: Content
```