### PR TITLE
Hide hidden fields from collection view by default

### DIFF
--- a/components/collection/collection-view.tsx
+++ b/components/collection/collection-view.tsx
@@ -66,7 +66,7 @@ export function CollectionView({
         });
       } else {
         pathAndFieldArray = schema.fields
-          .filter((field: any) => field?.type !== 'object')
+          .filter((field: any) => field?.type !== 'object' && !field.hidden)
           .map((field: any) => ({ path: field.name, field: field }));
       }
     } else {


### PR DESCRIPTION
Simple change to only show visible fields on the collection view (makes for better default setup).