### PR TITLE
Fix issue with empty rich text

### DIFF
--- a/fields/core/rich-text/index.tsx
+++ b/fields/core/rich-text/index.tsx
@@ -15,15 +15,15 @@ const read = (value: any, field: Field, config: Record<string, any>) => {
 
   const prefixInput = field.options?.input ?? config.object.media?.input;
   const prefixOutput = field.options?.output ?? config.object.media?.output;
-  
+
   return htmlSwapPrefix(html, prefixOutput, prefixInput, true);
 };
 
 const write = (value: any, field: Field, config: Record<string, any>) => {
-  let content = value;
-  
+  let content = value || '';
+
   content = rawToRelativeUrls(config.owner, config.repo, config.branch, content);
-  
+
   const prefixInput = field.options?.input ?? config.object.media?.input;
   const prefixOutput = field.options?.output ?? config.object.media?.output;
 
@@ -36,7 +36,7 @@ const write = (value: any, field: Field, config: Record<string, any>) => {
     });
     turndownService.use([tables, strikethrough]);
     turndownService.addRule("retain-html", {
-      filter: (node: any, options: any)  => (
+      filter: (node: any, options: any) => (
         (
           node.nodeName === "IMG" && (node.getAttribute("width") || node.getAttribute("height"))
         ) ||
@@ -50,10 +50,10 @@ const write = (value: any, field: Field, config: Record<string, any>) => {
     // We need to strip <colgroup> and <col> tags otherwise turndown won't convert tables
     content = content.replace(/<colgroup>.*?<\/colgroup>/g, '');
 
-    content = turndownService.turndown(content);    
+    content = turndownService.turndown(content);
   }
 
   return content;
 };
 
-export { EditComponent, ViewComponent, read, write};
+export { EditComponent, ViewComponent, read, write };


### PR DESCRIPTION
I received an error with an empty rich text field:

```
TypeError: Cannot read properties of undefined (reading 'matchAll')
    at getImgSrcs (lib/githubImage.ts:200:25)
    at rawToRelativeUrls (lib/githubImage.ts:88:18)
    at Object.write [as rich-text] (fields/core/rich-text/index.tsx:25:30)
    at eval (app/api/[owner]/[repo]/[branch]/files/[path]/route.ts:83:148)
    at eval (lib/schema.ts:46:29)
    at Array.forEach (<anonymous>)
    at traverse (lib/schema.ts:19:11)
    at eval (lib/schema.ts:43:12)
    at Array.forEach (<anonymous>)
    at traverse (lib/schema.ts:19:11)
    at deepMap (lib/schema.ts:53:9)
    at POST (app/api/[owner]/[repo]/[branch]/files/[path]/route.ts:83:51)
  198 | const getImgSrcs = (html: string) => {
  199 |   const regex = /<img [^>]*src=(?:"([^"]+)"|'([^']+)')[^>]*>/g;
> 200 |   return Array.from(html.matchAll(regex));
      |                         ^
  201 | }
  202 |
  203 | export { getRelativeUrl, getRawUrl, relativeToRawUrls, rawToRelativeUrls, swapPrefix, htmlSwapPrefix, encodePath, getImgSrcs };
```

This fixes the issue by making sure html is a string.