### PR TITLE
Feature: Add page titles to most routes

### DIFF
--- a/app/(main)/[owner]/[repo]/[branch]/collection/[name]/_layout.tsx
+++ b/app/(main)/[owner]/[repo]/[branch]/collection/[name]/_layout.tsx
@@ -1,3 +1,9 @@
+/**
+ * @FIX
+ *
+ * This layout has been disabled as it prevents navigation to child routes.
+ */
+
 import type { Metadata, ResolvingMetadata } from "next";
 import Default from "./page";
 import { type Page } from "@/types/page";

--- a/app/(main)/[owner]/[repo]/[branch]/collection/[name]/edit/[path]/layout.tsx
+++ b/app/(main)/[owner]/[repo]/[branch]/collection/[name]/edit/[path]/layout.tsx
@@ -1,0 +1,16 @@
+import type { Metadata, ResolvingMetadata } from "next";
+import Default from "./page";
+import { type PageWithPath } from "@/types/page";
+
+export async function generateMetadata(
+  { params }: PageWithPath,
+  parent: ResolvingMetadata
+): Promise<Metadata> {
+  return {
+    title: params.name,
+  };
+}
+
+export default function PageLayout(params: PageWithPath) {
+  return <Default {...params} />;
+}

--- a/app/(main)/[owner]/[repo]/[branch]/collection/[name]/edit/[path]/layout.tsx
+++ b/app/(main)/[owner]/[repo]/[branch]/collection/[name]/edit/[path]/layout.tsx
@@ -1,13 +1,15 @@
 import type { Metadata, ResolvingMetadata } from "next";
 import Default from "./page";
+import { getFileName } from "@/lib/utils/file";
 import { type PageWithPath } from "@/types/page";
 
 export async function generateMetadata(
   { params }: PageWithPath,
   parent: ResolvingMetadata
 ): Promise<Metadata> {
+  const filename = getFileName(decodeURIComponent(params.path));
   return {
-    title: params.name,
+    title: `Editing "${filename}" | ${params.name}`,
   };
 }
 

--- a/app/(main)/[owner]/[repo]/[branch]/collection/[name]/edit/[path]/page.tsx
+++ b/app/(main)/[owner]/[repo]/[branch]/collection/[name]/edit/[path]/page.tsx
@@ -4,18 +4,9 @@ import { useMemo } from "react";
 import { useConfig } from "@/contexts/config-context";
 import { getSchemaByName } from "@/lib/schema";
 import { EntryEditor } from "@/components/entry/entry-editor";
+import { PageWithPath } from "@/types/page";
 
-export default function Page({
-  params
-}: {
-  params: {
-    owner: string;
-    repo: string;
-    branch: string;
-    name: string;
-    path: string;
-  }
-}) {
+export default function Page({ params }: PageWithPath) {
   const { config } = useConfig();
   if (!config) throw new Error(`Configuration not found.`);
 

--- a/app/(main)/[owner]/[repo]/[branch]/collection/[name]/layout.tsx
+++ b/app/(main)/[owner]/[repo]/[branch]/collection/[name]/layout.tsx
@@ -1,0 +1,16 @@
+import type { Metadata, ResolvingMetadata } from "next";
+import Default from "./page";
+import { type Page } from "@/types/page";
+
+export async function generateMetadata(
+  { params }: Page,
+  parent: ResolvingMetadata
+): Promise<Metadata> {
+  return {
+    title: params.name,
+  };
+}
+
+export default function PageLayout(params: Page) {
+  return <Default {...params} />;
+}

--- a/app/(main)/[owner]/[repo]/[branch]/collection/[name]/new/layout.tsx
+++ b/app/(main)/[owner]/[repo]/[branch]/collection/[name]/new/layout.tsx
@@ -7,7 +7,7 @@ export async function generateMetadata(
   parent: ResolvingMetadata
 ): Promise<Metadata> {
   return {
-    title: params.name,
+    title: `Creating ${params.name}`,
   };
 }
 

--- a/app/(main)/[owner]/[repo]/[branch]/collection/[name]/new/layout.tsx
+++ b/app/(main)/[owner]/[repo]/[branch]/collection/[name]/new/layout.tsx
@@ -1,0 +1,16 @@
+import type { Metadata, ResolvingMetadata } from "next";
+import Default from "./page";
+import { type PageWithPath } from "@/types/page";
+
+export async function generateMetadata(
+  { params }: PageWithPath,
+  parent: ResolvingMetadata
+): Promise<Metadata> {
+  return {
+    title: params.name,
+  };
+}
+
+export default function PageLayout(params: PageWithPath) {
+  return <Default {...params} />;
+}

--- a/app/(main)/[owner]/[repo]/[branch]/collection/[name]/page.tsx
+++ b/app/(main)/[owner]/[repo]/[branch]/collection/[name]/page.tsx
@@ -5,17 +5,9 @@ import { useSearchParams } from "next/navigation";
 import { useConfig } from "@/contexts/config-context";
 import { getSchemaByName } from "@/lib/schema";
 import { CollectionView } from "@/components/collection/collection-view";
+import { type Page } from "@/types/page";
 
-export default function Page({
-  params
-}: {
-  params: {
-    owner: string;
-    repo: string;
-    branch: string;
-    name: string
-  }
-}) {
+export default function Page({ params }: Page) {
   const { config } = useConfig();
   if (!config) throw new Error(`Configuration not found.`);
 

--- a/app/(main)/[owner]/[repo]/[branch]/file/[name]/layout.tsx
+++ b/app/(main)/[owner]/[repo]/[branch]/file/[name]/layout.tsx
@@ -1,0 +1,16 @@
+import type { Metadata, ResolvingMetadata } from "next";
+import Default from "./page";
+import { type Page } from "@/types/page";
+
+export async function generateMetadata(
+  { params }: Page,
+  parent: ResolvingMetadata
+): Promise<Metadata> {
+  return {
+    title: params.name,
+  };
+}
+
+export default function PageLayout(params: Page) {
+  return <Default {...params} />;
+}

--- a/app/(main)/[owner]/[repo]/[branch]/file/[name]/page.tsx
+++ b/app/(main)/[owner]/[repo]/[branch]/file/[name]/page.tsx
@@ -4,17 +4,9 @@ import { useMemo } from "react";
 import { useConfig } from "@/contexts/config-context";
 import { EntryEditor } from "@/components/entry/entry-editor";
 import { getSchemaByName } from "@/lib/schema";
+import { type Page } from "@/types/page";
 
-export default function Page({
-  params
-}: {
-  params: {
-    owner: string;
-    repo: string;
-    branch: string;
-    name: string;
-  }
-}) {
+export default function Page({ params }: Page) {
   const { config } = useConfig();
   if (!config) throw new Error(`Configuration not found.`);
   

--- a/app/(main)/[owner]/[repo]/[branch]/media/[name]/layout.tsx
+++ b/app/(main)/[owner]/[repo]/[branch]/media/[name]/layout.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from "next";
+import Default from "./page";
+import { type PageNameOnly } from "@/types/page";
+
+export const metadata: Metadata = {
+  title: "Media",
+}
+
+export default function PageLayout(params: PageNameOnly) {
+  return <Default {...params} />;
+}

--- a/app/(main)/[owner]/[repo]/[branch]/media/[name]/page.tsx
+++ b/app/(main)/[owner]/[repo]/[branch]/media/[name]/page.tsx
@@ -3,14 +3,9 @@
 import { useSearchParams } from "next/navigation";
 import { useConfig } from "@/contexts/config-context";
 import { MediaView} from "@/components/media/media-view";
+import { PageNameOnly } from "@/types/page";
 
-export default function Page({
-  params
-}: {
-  params: {
-    name: string;
-  }
-}) {
+export default function Page({ params }: PageNameOnly) {
   const searchParams = useSearchParams();
   const path = searchParams.get("path") || "";
 

--- a/app/(main)/[owner]/[repo]/[branch]/settings/layout.tsx
+++ b/app/(main)/[owner]/[repo]/[branch]/settings/layout.tsx
@@ -1,0 +1,9 @@
+import { Metadata } from "next";
+import Page from "./page"; // import your Demo's page
+
+export const metadata: Metadata = {
+  title: "Settings",
+};
+export default function PageLayout() {
+  return <Page />;
+}

--- a/app/(main)/settings/layout.tsx
+++ b/app/(main)/settings/layout.tsx
@@ -1,0 +1,9 @@
+import { Metadata } from "next";
+import Page from "./page";
+
+export const metadata: Metadata = {
+  title: "Settings",
+};
+export default function PageLayout() {
+  return <Page />;
+}

--- a/types/page.ts
+++ b/types/page.ts
@@ -1,0 +1,20 @@
+export interface Page {
+  params: {
+    owner: string;
+    repo: string;
+    branch: string;
+    name: string;
+  }
+}
+
+export interface PageWithPath extends Page {
+  params: {
+    path: string;
+  } & Page["params"];
+}
+
+export interface PageNameOnly {
+  params: {
+    name: string;
+  }
+}


### PR DESCRIPTION
I've found it difficult to navigate the router history while testing a site as every page is titled "Pages CMS".

I've had a stab at creating more meaningful page titles. I've had to disable the page title for the `collection/[name]` route as it prevented navigation to child routes. And I've not loaded content to get the correct title opting instead for the last fragment of the path. Regardless--I now find this makes navigating back through the history more usable.