### PR TITLE
Feature: Collapsible fields

### DIFF
--- a/components/entry/entry-form.tsx
+++ b/components/entry/entry-form.tsx
@@ -201,6 +201,7 @@ const ListField = ({
                       {collapsible && (
                           <div className="mt-1 pl-1">
                             <p className="text-base font-medium text-gray-900 dark:text-gray-100">
+                              {/* TODO: Make stateful - update as user types, and after save (without reload) */}
                               {typeof collapsible === 'object' ? generateFieldLabel(collapsible.label ?? `Item ${index + 1}`, arrayField) : `Item ${index + 1}`}
                             </p>
                           </div>

--- a/components/entry/entry-form.tsx
+++ b/components/entry/entry-form.tsx
@@ -114,9 +114,20 @@ const ListField = ({
     control,
     name: fieldName,
   });
+  
+  const arrayFieldsRef = useRef(arrayFields);
+
+  useEffect(() => {
+    if (arrayFieldsRef.current.length < arrayFields.length) {
+      const newId = arrayFields[arrayFields.length - 1].id;
+      setExpandedFields((prev) => [...prev, newId]);
+    }
+    arrayFieldsRef.current = arrayFields;
+  }, [arrayFields]);
+
   // TODO: why is this not used?
   const { errors } = useFormState({ control });
-  
+
   const [ expandedFields, setExpandedFields ] = useState<string[]>(
     typeof collapsible === 'object' ? (collapsible.expanded ? arrayFields.map(field => field.id) : []) : []
   ); // Stores arrayFields ID
@@ -207,8 +218,7 @@ const ListField = ({
                       {collapsible && (
                           <div className="mt-1 pl-1">
                             <p className="text-base font-medium text-gray-900 dark:text-gray-100">
-                              {/* TODO: Make stateful - update as user types, and after save (without reload) */}
-                              {typeof collapsible === 'object' ? generateFieldLabel(collapsible.label ?? `Item ${index + 1}`, arrayField) : `Item ${index + 1}`}
+                              {typeof collapsible === 'object' ? generateFieldLabel(collapsible.label ?? `Item #${arrayField.id}`, control._formValues[field.name][index]) : `Item #${arrayField.id}`}
                             </p>
                           </div>
                       )}
@@ -239,12 +249,10 @@ const ListField = ({
                   variant="outline"
                   size="sm"
                   onClick={() => {
-                    // TODO: Fix, ID isnt available
-                    const newField = field.type === 'object'
+                    append(field.type === 'object'
                       ? initializeState(field.fields, {})
-                      : getDefaultValue(field);
-                    append(newField);
-                    setExpandedFields((prev) => [...prev, newField.id]);
+                      : getDefaultValue(field)
+                    );
                   }}
                   className="gap-x-2"
                 >

--- a/lib/configSchema.ts
+++ b/lib/configSchema.ts
@@ -85,6 +85,19 @@ const FieldObjectSchema: z.ZodType<any> = z.lazy(() => z.object({
       message: "'list' must be either a boolean or an object with 'min' and 'max' properties."
     }).strict()
   ]).optional(),
+  collapsible: z.union([
+    z.boolean(),
+    z.object({
+      expanded: z.boolean({
+        message: "'expanded' must be a boolean."
+      }).optional(),
+      label: z.string({
+        message: "'label' must be a valid string."
+      }).optional(),
+    }, {
+      message: "'collapsible' must be either a boolean or an object with 'expanded' and 'label' properties."
+    }).strict()
+  ]).optional(),
   hidden: z.boolean({
     message: "'hidden' must be a boolean."
   }).optional().nullable(),

--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -267,6 +267,19 @@ const generateFilename = (
   });
 };
 
+// TODO: Make generic and merge with generateFilename
+// Generate a collapsible field label
+const generateFieldLabel = (
+  pattern: string,
+  state: Record<string, any>
+) => {
+  // Replace field placeholders
+  return pattern.replace(/\{([^}]+)\}/g, (_, fieldName) => {
+    const value = safeAccess(state, fieldName);
+    return value ? String(value) : "";
+  });
+};
+
 // Extract a date from a filename when possible
 function getDateFromFilename(filename: string) {
   const pattern = /^(\d{4})-(\d{2})-(\d{2})-/;
@@ -293,6 +306,7 @@ export {
   getFieldByPath,
   getPrimaryField,
   generateFilename,
+  generateFieldLabel,
   getDateFromFilename,
   generateZodSchema,
   safeAccess,

--- a/types/field.ts
+++ b/types/field.ts
@@ -5,6 +5,7 @@ export type Field = {
   type: "boolean" | "code" | "date" | "image" | "number" | "object" | "rich-text" | "select" | "string" | "text" | "uuid" | string;
   default?: any;
   list?: boolean | { min?: number; max?: number; default?: any };
+  collapsible?: boolean | { expanded?: boolean, label?: string };
   hidden?: boolean | null;
   required?: boolean | null;
   pattern?: string | { regex: string; message?: string };


### PR DESCRIPTION
Adds ability to configure a field collapsed:

![CleanShot 2025-04-05 at 11 02 49@2x](https://github.com/user-attachments/assets/1364f783-cf2e-4372-b62b-ef093ac05ca4)

![CleanShot 2025-04-05 at 11 03 00@2x](https://github.com/user-attachments/assets/d1b4ef6c-e9e7-4e0e-990f-afa54f621b88)

Example configuration:

```yaml
content:
  - name: database
    label: Database
    path: database.json
    type: file
    fields:
      - name: users
        label: Users
        type: object
        list: true
        collapsible:
          label: "User {name} ({age} years old)"
          expanded: true
        fields:
         - name: name
           type: string
         - name: age
           type: number
```

More examples:

```yaml
        collapsible: true
```

```yaml
        collapsible:
          expanded: true
```

```yaml
        collapsible:
          label: "User {name} ({age} years old)"
```

Left to do:

- [ ] Address todos
- [ ] Confirm approach with maintainer
- [ ] Approving review
- [ ] Update docs (pages-cms/website)