### PR TITLE
Update year and author on Licence

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) [year] [fullname]
+Copyright 2025 Ronan Berder
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
The year and author was missing updated that! 

Corrected also this time around pulled from `development` branch ✌️
