### PR TITLE
Improve sorting to include directories using React Table

### DIFF
--- a/components/collection/collection-table.tsx
+++ b/components/collection/collection-table.tsx
@@ -199,48 +199,50 @@ export function CollectionTable<TData extends TableData>({
               <TableRow key={row.id}>
                 {
                   row.original.type === "dir"
-                    ? <>
-                      <TableCell
-                        colSpan={columns.length - 1}
-                        className="px-3 first:pl-0 last:pr-0 border-b py-0 h-14"
-                        style={{
-                          paddingLeft: row.depth > 0
-                            ? `${row.depth * 2}rem`
-                            : undefined
-                        }}
-                      >
-                        {isTree
-                          ? <button
-                              className="flex items-center gap-x-2 font-medium"
-                              onClick={() => handleRowExpansion(row as Row<TData>)}
-                            >
-                              {loadingRows[row.id]
-                                ? <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
-                                : row.getIsExpanded()
-                                  ? <FolderOpen className="h-4 w-4" />
-                                  : <Folder className="h-4 w-4" />
+                    ? row.getVisibleCells().map((cell) => (
+                        <TableCell
+                          key={cell.id}
+                          className={cn(
+                            "px-3 first:pl-0 last:pr-0 border-b py-0 h-14",
+                            cell.column.columnDef.meta?.className,
+                          )}
+                          style={{
+                            paddingLeft: (cell.column.id === primaryField && row.depth > 0)
+                              ? `${row.depth * 2}rem`
+                              : undefined
+                          }}
+                        >
+                          {cell.column.id === primaryField ? (
+                            <div className="flex items-center gap-x-2">
+                              {row.depth > 0 && <LShapeIcon className="h-4 w-4 text-muted-foreground opacity-50"/>}
+                              {isTree
+                                ? <button
+                                    className="flex items-center gap-x-2 font-medium"
+                                    onClick={() => handleRowExpansion(row as Row<TData>)}
+                                  >
+                                    {loadingRows[row.id]
+                                      ? <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+                                      : row.getIsExpanded()
+                                        ? <FolderOpen className="h-4 w-4" />
+                                        : <Folder className="h-4 w-4" />
+                                    }
+                                    {row.original.name}
+                                  </button>
+                                : <Link
+                                    className="flex items-center gap-x-2 font-medium"
+                                    href={`${pathname}?path=${encodeURIComponent(row.original.path)}`}
+                                  >
+                                    <Folder className="h-4 w-4" />
+                                    {row.original.name}
+                                  </Link>
                               }
-                              {row.original.name}
-                            </button>
-                          : <Link
-                              className="flex items-center gap-x-2 font-medium"
-                              href={`${pathname}?path=${encodeURIComponent(row.original.path)}`}
-                            >
-                              <Folder className="h-4 w-4" />
-                              {row.original.name}
-                            </Link>
-                        }
-                      </TableCell>
-                      <TableCell className="px-3 first:pl-0 last:pr-0 border-b py-0 h-14">
-                        {
-                          (() => {
-                            const lastCell = row.getVisibleCells()[row.getVisibleCells().length - 1];
-                            return flexRender(lastCell.column.columnDef.cell, lastCell.getContext());
-                          })()
-                        }
-                      </TableCell>
-                      </>
-                    : row.getVisibleCells().map((cell, index) => (
+                            </div>
+                          ) : cell.column.id === "actions" ? (
+                            flexRender(cell.column.columnDef.cell, cell.getContext())
+                          ) : null}
+                        </TableCell>
+                      ))
+                    : row.getVisibleCells().map((cell) => (
                       <TableCell
                         key={cell.id}
                         className={cn(

--- a/components/collection/collection-view.tsx
+++ b/components/collection/collection-view.tsx
@@ -275,7 +275,14 @@ export function CollectionView({
       
       return {
         accessorKey: path,
-        accessorFn: (originalRow: any) => safeAccess(originalRow.fields, path),
+        accessorFn: (originalRow: any) => {
+          const fieldValue = safeAccess(originalRow.fields, path);
+          if (fieldValue !== undefined) return fieldValue;
+          if (originalRow.type === "dir" && field.name === primaryField) {
+            return originalRow.name;
+          }
+          return fieldValue;
+        },
         header: field?.label ?? field.name,
         meta: { className: field.name === primaryField ? "truncate w-full min-w-[12rem] max-w-[1px]" : "" },
         cell: ({ cell, row }: { cell: any, row: any }) => {


### PR DESCRIPTION
Thank you for developing such a great CMS!

This pull request improves the table sorting behavior so that directories are handled the same way as files when using React Table.

## Before
- Directory rows were rendered with `colSpan` across multiple columns
- This bypassed the React Table column definitions (`accessorFn`)
- As a result, sorting did not apply to directory rows, leading to inconsistent behavior

## After
- Directory rows are now processed via `row.getVisibleCells()` just like file rows
- All columns' `accessorFn` are now properly called for both directories and files
- This enables consistent and expected sorting behavior

It's a small change, but I hope it improves the overall UX of the content listing.