### PR TITLE
Handle hidden values in entry form

### DIFF
--- a/app/api/[owner]/[repo]/[branch]/entries/[path]/route.ts
+++ b/app/api/[owner]/[repo]/[branch]/entries/[path]/route.ts
@@ -122,7 +122,6 @@ const parseContent = (
         contentObject,
         entryFields,
         (value, field) => {
-          if (field.hidden) return;
           const type = field.type;
           if (typeof type === 'string' && readFns[type]) {
             return readFns[type](value, field, config);


### PR DESCRIPTION
Fixes #291.

Hidden values are entered into the entry form so that it can be evaluated whether they are empty and the default should be used or not. The user does not see any change because the hidden fields are displayed.