### PR TITLE
Gitignore .env* files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,8 +25,9 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
-# local env files
-.env*.local
+# env files
+.env*
+!.env.local.example
 
 # vercel
 .vercel


### PR DESCRIPTION
The project README recommends using `.env` file, so it must be in `.gitignore`.

NextJS itself also [recommends](https://nextjs.org/docs/app/guides/environment-variables#loading-environment-variables) ignoring all `.env` files:

> The default `create-next-app` template ensures all `.env` files are added to your `.gitignore`. You almost never want to commit these files to your repository.