### PR TITLE
Fix entry-editor and entry-form refresh

### DIFF
--- a/components/entry/entry-editor.tsx
+++ b/components/entry/entry-editor.tsx
@@ -101,6 +101,23 @@ export function EntryEditor({
     [schema, config.owner, config.repo, config.branch, path]
   );
 
+  const fetchData = async (
+    owner: string, 
+    repo: string, 
+    branch: string, 
+    path: string, 
+    name: string
+  ) => {
+      const response = await fetch(`/api/${owner}/${repo}/${encodeURIComponent(branch)}/entries/${encodeURIComponent(path)}?name=${encodeURIComponent(name)}`);
+      if (!response.ok) throw new Error(`Failed to fetch entry: ${response.status} ${response.statusText}`);
+
+      const data: any = await response.json();
+      
+      if (data.status !== "success") throw new Error(data.message);
+
+      return data;
+  };
+
   useEffect(() => {
     const fetchEntry = async () => {
       if (path) {
@@ -108,12 +125,7 @@ export function EntryEditor({
         setError(null);
 
         try {
-          const response = await fetch(`/api/${config.owner}/${config.repo}/${encodeURIComponent(config.branch)}/entries/${encodeURIComponent(path)}?name=${encodeURIComponent(name)}`);
-          if (!response.ok) throw new Error(`Failed to fetch entry: ${response.status} ${response.statusText}`);
-
-          const data: any = await response.json();
-          
-          if (data.status !== "success") throw new Error(data.message);
+          const data: any = await fetchData(config.owner, config.repo, config.branch, path, name);
           
           setEntry(data.data);
           setSha(data.data.sha);
@@ -177,7 +189,10 @@ export function EntryEditor({
       
         if (data.status !== "success") throw new Error(data.message);
         
-        if (data.data.sha !== sha) setSha(data.data.sha);
+        let remoteData = await fetchData(config.owner, config.repo, config.branch, savePath, name);
+
+        setEntry(remoteData.data);
+        setSha(remoteData.data.sha);
 
         if (!path && schema.type === "collection") router.push(`/${config.owner}/${config.repo}/${encodeURIComponent(config.branch)}/collection/${encodeURIComponent(name)}/edit/${encodeURIComponent(data.data.path)}`);
 

--- a/components/entry/entry-form.tsx
+++ b/components/entry/entry-form.tsx
@@ -6,7 +6,7 @@ import {
   useForm,
   useFieldArray,
   useFormState,
-  useFormContext
+  useFormContext,
 } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { editComponents } from "@/fields/registry";
@@ -602,6 +602,12 @@ const EntryForm = ({
     defaultValues,
     reValidateMode: "onSubmit"
   });
+
+  useEffect(() => {
+    // keeps dirty values in case modifications are made
+    // during a submit. this only happens if requests are slow
+    form.reset(defaultValues, {keepDirtyValues: true});
+  }, [defaultValues]);
 
   const { isDirty } = useFormState({
     control: form.control


### PR DESCRIPTION
Addressing #321. I wanted to make a PR against develop, but it's behind main. Will update when develop is up to date.

The problem is that after submitting the changes, the form's `defaultValues` isn't reset to the newest version of the file. `useForm` caches `defaultValues` as per the [documentation.](https://react-hook-form.com/docs/useform#defaultValues)

# Changes
entry-editor.tsx:
- Extracted the data-fetching logic into a separate function, `fetchData`.
- After submitting the form, fetch the latest entry version and call `setEntry` + `setSha`. This ensures the updated entryContentObject trickles down to `entry-form.tsx`.

entry-form.tsx:
- Added a `useEffect` to reset the form’s default values when they change.

[fixed.webm](https://github.com/user-attachments/assets/2da25c71-675b-416c-8670-423c1ce1bafc)
