### PR TITLE
Fix richtext img url converting when branch name has a slash

### DIFF
--- a/lib/githubImage.ts
+++ b/lib/githubImage.ts
@@ -120,7 +120,7 @@ const rawToRelativeUrls = (
     const quote = match[1] ? "\"" : "'";
 
     if (src.startsWith("https://raw.githubusercontent.com/")) {
-      let relativePath = src.replace(new RegExp(`https://raw\\.githubusercontent\\.com/${owner}/${repo}/${encodeURIComponent(branch)}/`, "gi"), "");
+      let relativePath = src.replace(new RegExp(`https://raw\\.githubusercontent\\.com/${owner}/${repo}/${encodePath(branch)}/`, "gi"), "");
       relativePath = relativePath.split("?")[0];
 
       if (!encode) relativePath = decodeURIComponent(relativePath);


### PR DESCRIPTION
## The issue:

the "raw.githubusercontent" url is not replaced with the config's "output" property. Happens only with slash-containing branches like `feature/onetwothree`

Try to save this:

<img width="400"  alt="image" src="https://github.com/user-attachments/assets/30319233-d79f-4a14-b11a-6c541115b9b2" />

### The result:

instead of url in format of `$output/$relativeUrl` it's `https://raw.github...../$relativeUrl`

<img width="1347" height="441" alt="image" src="https://github.com/user-attachments/assets/ae3744eb-9a88-4ed7-942a-25fe72b6220e" />

## Reproduction steps:

1. use a branch containing a slash (e.g. `feature/foobar`). Branches like `develop` or `feature_one-123` are fine.
2. edit rich-text `body` field of either a collection or a single md. It must be a `body` field. It doesn't affect the rich-text when used in a block field.
3. add an image to the body.
4. save
5. the non-converted URL is committed.

## Fix:

`githubImage.ts` already has `encodePath` function which seems to handle this problem.

commit: 3b735b0 seems to fix some bug (but doesn't say what that is). Is there a reason why it's specifically `encodeURIComponent` and not the `encodePath` function that was already there?

Shouldn't `encodePath` be used everywhere in `githubImage.ts` instead of `encodeURIComponent`?