### PR TITLE
Issue/338 fix performance

### DIFF
--- a/components/entry/entry-form.tsx
+++ b/components/entry/entry-form.tsx
@@ -199,20 +199,6 @@ const ListField = ({
   }, []);
 
   const handleDragEnd = useCallback((event: any) => {
-    // Note: We use the callback form but we still need fresh data for `arrayMove` and `move`
-    // However, since `dnd-kit` provides `active` and `over` IDs, we can use those.
-    // We rely on `arrayFields` and `fieldValues` from the closure.
-    // This technically means `handleDragEnd` changes every render, breaking memoization of DndContext props if strictly checked.
-    // BUT, the critical part is that ListField render shouldn't cause *all children* to re-render.
-    // We achieve this by memoizing SortableListFieldItem.
-    // `DndContext` changing props isn't the main perf bottleneck, it's the recursive rendering of 100s of fields.
-
-    // To properly fix handleDragEnd to be stable would require `useEvent` pattern or refs for values, 
-    // but simply memoizing the `SortableListFieldItem` is the 80/20 win here.
-
-    // We will keep it inline/simple but wrap in useCallback with deps to show intent, 
-    // even if deps change often.
-
     const { active, over } = event;
     if (active.id !== over.id) {
       const oldIndex = arrayFields.findIndex(item => item.id === active.id);


### PR DESCRIPTION
Fixes #338 
This PR addresses significant performance lag encountered when interacting with large lists (e.g., reordering items, typing in sub-fields) in the EntryForm.

**The Problem**
Previously, any state update within the ListField (such as hovering, dragging, or typing) caused a "ripple effect" where every single item in the list would re-render. For lists with complex children (like the Publications or Members sections), this resulted in noticeable UI blocking and lag.

**The Solution**
I have implemented a standard React performance optimization strategy:

1.Component Extraction & Memoization:
- Extracted list items into a new SortableListFieldItem component.
- Wrapped it in React.memo so it only re-renders if its specific props (data, index, open state) change.

2.Stable Callbacks:
- Wrapped all event handlers (toggleOpen, removeItem, handleDragEnd, etc.) in useCallback to prevent breaking memoization in child components.

3.Recursive Optimization:
- Applied React.memo to SingleField, ObjectField, and BlocksField to ensure the benefits propagate down the component tree.

**Performance Impact**
- **Before:** O(n) re-renders on every interaction (linear growth with list size).
- **After:** O(1) or O(small_subset) re-renders for most interactions.
- Validated via build and type checks.

**Technical Notes**
- **Trade-off on handleDragEnd stability:** The handleDragEnd function technically updates heavily because it depends on arrayFields and fieldValues to calculate moves correctly. While this breaks strict prop stability for the DndContext, it is an intentional trade-off. We achieved the core performance win by memoizing the children (SortableListFieldItem), ensuring that even if the context updates, the hundreds of list items do not re-render unless involved in the drag operation. This provides the "80/20" optimization win without requiring complex ref/useEvent patterns.