### PR TITLE
feat: Allow block discriminator field in view columns

### DIFF
--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -307,11 +307,23 @@ function interpolate(input: string, data: Record<string, any>, prefixFallback?: 
 function getFieldByPath(schema: Field[], path: string): Field | undefined {
   const [first, ...rest] = path.split('.');
   const field = schema.find(f => f.name === first);
-  
-  return !field ? undefined
-    : rest.length === 0 ? field
-    : field.type === 'object' && field.fields ? getFieldByPath(field.fields, rest.join('.'))
-    : undefined;
+
+  if (!field) return undefined;
+  if (rest.length === 0) return field;
+
+  if (field.type === 'object' && field.fields) {
+    return getFieldByPath(field.fields, rest.join('.'));
+  }
+
+  // Handle block discriminator field (e.g., "content._block")
+  if (field.type === 'block' && rest.length === 1) {
+    const blockKey = field.blockKey || '_block';
+    if (rest[0] === blockKey) {
+      return { name: blockKey, type: 'string', label: field.label || 'Type' } as Field;
+    }
+  }
+
+  return undefined;
 }
 
 // Get the primary field for a schema


### PR DESCRIPTION
## Summary

This PR enables displaying the block discriminator field (e.g., `_block`) in collection view columns.

### Problem

When using block fields, there's no way to display the block type in the list view. Users who want to show which block type each entry uses (e.g., "image", "video", "gallery") currently cannot do so because:

1. `getFieldByPath` only traverses into `object` type fields, not `block` types
2. Block fields are explicitly excluded from view columns

### Solution

Modified `getFieldByPath` in `lib/schema.ts` to recognize the block discriminator field (defaulting to `_block`, or a custom `blockKey` if configured). When a path like `content._block` is requested, it returns a virtual string field definition.

### Usage

In `.pages.yml`:

```yaml
fields:
  - name: content
    type: block
    blocks:
      - name: image
        # ...
      - name: video
        # ...

view:
  fields: [title, date, content._block]
```

This will display "image", "video", etc. in the list view column.

### Changes

- `lib/schema.ts`: Extended `getFieldByPath` to handle block discriminator fields (~10 lines added)

### Testing

Tested with a collection of 3300+ posts using various block types (image, video, gallery, quote, link, post). The column correctly displays the block type for each entry.