### PR TITLE
fix: block field handling with custom blockKey and component references

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -177,6 +177,10 @@ function resolveComponent(field: any, componentsMap: Record<string, any>): any {
       });
       result.name = originalName;
       result.type = componentType;
+      // Preserve blockKey from original field (used for block type discrimination)
+      if (field.blockKey !== undefined) {
+        result.blockKey = field.blockKey;
+      }
     } else {
       console.error(`Component reference "${componentKey}" could not be resolved.`);
       delete result.component; // Remove the broken reference

--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -35,8 +35,8 @@ const deepMap = (
                   const blockDef = field.blocks?.find(b => b.name === blockName);
                   if (blockDef) {
                     const innerResult = traverse(item, blockDef.fields || []);
-                    // Merge discriminator back after processing inner fields
-                    return { [blockKey]: blockName, ...innerResult }; 
+                    // Merge discriminator AFTER innerResult so it wins over any undefined value
+                    return { ...innerResult, [blockKey]: blockName };
                   }
                   return item;
                 } else {
@@ -53,8 +53,8 @@ const deepMap = (
         const blockDef = field.blocks?.find(b => b.name === blockName);
         if (blockDef && value) {
           const innerResult = traverse(value, blockDef.fields || []);
-          // Merge discriminator back after processing inner fields
-          result[field.name] = { [blockKey]: blockName, ...innerResult };
+          // Merge discriminator AFTER innerResult so it wins over any undefined value
+          result[field.name] = { ...innerResult, [blockKey]: blockName };
         } else {
           result[field.name] = value;
         }
@@ -139,9 +139,13 @@ const generateZodSchema = (
               return null;
             }
             const base = z.object({
-              [discriminator]: z.literal(blockDef.name) 
+              [discriminator]: z.literal(blockDef.name)
             });
-            const blockFieldsSchema = z.object(buildSchemaObject(blockDef.fields || []));
+            // Filter out the discriminator field to prevent it from overwriting the literal
+            const fieldsWithoutDiscriminator = (blockDef.fields || []).filter(
+              (f: Field) => f.name !== discriminator
+            );
+            const blockFieldsSchema = z.object(buildSchemaObject(fieldsWithoutDiscriminator));
             return base.merge(blockFieldsSchema); 
           }).filter(schema => schema !== null) as z.ZodObject<any>[];
 


### PR DESCRIPTION
## Summary

Fixes three interconnected bugs that prevent `type: block` fields from working correctly when using:
- Custom `blockKey` (e.g., `blockKey: type` instead of default `_block`)
- Component references in block definitions (e.g., `component: heroBlock`)

These bugs caused blocks to show "Choose content block:" instead of recognizing existing block data.

## Changes

### 1. Filter discriminator from Zod schema (lib/schema.ts)

When generating Zod validation schemas for blocks, the discriminator field is now filtered out before building the block's field schema. This prevents `z.string()` from overwriting `z.literal("hero")` during the merge.

### 2. Preserve blockKey during component resolution (lib/config.ts)

The `resolveComponent()` function now explicitly preserves `blockKey` after merging component definitions. Previously, this property was lost during the merge operation.

### 3. Fix discriminator merge order (lib/schema.ts)

Changed the spread order in `deepMap` from:
```typescript
{ [blockKey]: blockName, ...innerResult }
```
to:
```typescript
{ ...innerResult, [blockKey]: blockName }
```

This ensures the discriminator value takes precedence over any `undefined` values that may come from processing hidden fields in the block definition.

## Test Plan

1. Create a `.pages.yml` with block fields using custom `blockKey: type`
2. Define blocks that reference components (e.g., `component: heroBlock`)
3. Create content files with blocks containing the discriminator (e.g., `type: hero`)
4. Verify blocks load correctly in the editor with existing data populated
5. Verify adding, editing, and removing blocks works correctly