### PR TITLE
Fix references endpoint for populating drop downs.

### DIFF
--- a/app/api/[owner]/[repo]/[branch]/references/[name]/route.ts
+++ b/app/api/[owner]/[repo]/[branch]/references/[name]/route.ts
@@ -29,12 +29,7 @@ type ParsedReferenceItem = {
 const extractTemplateFields = (template: string) =>
   Array.from(template.matchAll(/\{([^}]+)\}/g))
     .map((match) => match[1])
-    .filter((token) =>
-      token === "primary" ||
-      token.startsWith("fields.") ||
-      token === "name" ||
-      token === "path"
-    );
+    .filter((token) => token && token.length > 0);
 
 export async function GET(
   request: NextRequest,


### PR DESCRIPTION
Currently (v2.0.2) reference drop downs are always empty. Removing this field filter restores the expected behaviour. 

My URL for that endpoint looked like this:
http://localhost:3001/api/queenvictoria/xxxxxxxx/main/references/writings?query=&searchFields=publication.publication_date%2Cauthors%2Ctitle&valueTemplate=%7Bid%7D&labelTemplate=%7Bpublication.publication_date%7D+%7Bauthors%7D+%7Btitle%7D](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

Whereas this one returns all writings:
[http://localhost:3001/api/queenvictoria/xxxxxxxx/main/references/writings?query=&searchFields=publication.publication_date%2Cauthors%2Ctitle](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
