### PR TITLE
Add colocated media paths handling

### DIFF
--- a/fields/core/file/edit-component.tsx
+++ b/fields/core/file/edit-component.tsx
@@ -47,12 +47,18 @@ type FieldOptions = {
   rename?: boolean | "safe" | "random";
 };
 
-const FileTeaser = ({ file, config, onRemove, getFileIcon }: { 
+const FileTeaser = ({ file, config, mediaInput, onRemove, getFileIcon }: { 
   file: string;
   config: Pick<Config, "owner" | "repo" | "branch">;
+  mediaInput?: string;
   onRemove?: () => void;
   getFileIcon: (file: string) => React.ReactNode;
 }) => {
+  const normalizedFile = file.replace(/^\.\//, '').replace(/^\//, '');
+  const githubPath = mediaInput && !file.startsWith(mediaInput) && !file.startsWith('http')
+    ? `${mediaInput}/${normalizedFile}`
+    : file;
+
   return (
     <>
       <div title={file} className="flex items-center gap-x-1 px-2 h-9 rounded-md bg-muted truncate text-sm">
@@ -65,7 +71,7 @@ const FileTeaser = ({ file, config, onRemove, getFileIcon }: {
           <TooltipTrigger asChild>
             <Button type="button" variant="ghost" size="icon" asChild className="text-muted-foreground hover:text-foreground">
               <a
-                href={`https://github.com/${config.owner}/${config.repo}/blob/${config.branch}/${file}`}
+                href={`https://github.com/${config.owner}/${config.repo}/blob/${config.branch}/${githubPath}`}
                 target="_blank"
                 rel="noopener noreferrer"
                 aria-label={`View ${getFileName(file)} on GitHub`}
@@ -98,10 +104,11 @@ const FileTeaser = ({ file, config, onRemove, getFileIcon }: {
   )
 };
 
-const SortableItem = ({ id, file, config, onRemove, getFileIcon, readonly = false }: { 
+const SortableItem = ({ id, file, config, mediaInput, onRemove, getFileIcon, readonly = false }: { 
   id: string;
   file: string;
   config: Pick<Config, "owner" | "repo" | "branch">;
+  mediaInput?: string;
   onRemove?: () => void;
   getFileIcon: (file: string) => React.ReactNode;
   readonly?: boolean;
@@ -132,7 +139,7 @@ const SortableItem = ({ id, file, config, onRemove, getFileIcon, readonly = fals
           </Button>
         )}
         
-        <FileTeaser file={file} config={config} onRemove={onRemove} getFileIcon={getFileIcon} />
+        <FileTeaser file={file} config={config} mediaInput={mediaInput} onRemove={onRemove} getFileIcon={getFileIcon} />
       </div>
     </div>
   );
@@ -351,6 +358,7 @@ const EditComponent = forwardRef((props: EditorProps, ref: React.Ref<HTMLInputEl
                         id={file.id}
                         file={file.path}
                         config={config}
+                        mediaInput={mediaConfig?.input}
                         onRemove={isReadonly ? undefined : () => handleRemove(file.id)}
                         getFileIcon={getFileIcon}
                         readonly={isReadonly}
@@ -361,7 +369,7 @@ const EditComponent = forwardRef((props: EditorProps, ref: React.Ref<HTMLInputEl
               </div>
             ) : (
               <div className="grid grid-cols-[1fr_auto] items-center gap-2 pl-3 pr-1 bg-muted rounded-md h-10">
-                <FileTeaser file={files[0].path} config={config} onRemove={isReadonly ? undefined : () => handleRemove(files[0].id)} getFileIcon={getFileIcon} />
+                <FileTeaser file={files[0].path} config={config} mediaInput={mediaConfig?.input} onRemove={isReadonly ? undefined : () => handleRemove(files[0].id)} getFileIcon={getFileIcon} />
               </div>
             )
           )}

--- a/fields/core/image/edit-component.tsx
+++ b/fields/core/image/edit-component.tsx
@@ -47,11 +47,17 @@ type FieldOptions = {
   rename?: boolean | "safe" | "random";
 };
 
-const ImageTeaser = ({ file, config, onRemove }: { 
+const ImageTeaser = ({ file, config, mediaInput, onRemove }: { 
   file: string;
   config: Pick<Config, "owner" | "repo" | "branch">;
+  mediaInput?: string;
   onRemove?: () => void;
 }) => {
+  const normalizedFile = file.replace(/^\.\//, '').replace(/^\//, '');
+  const githubPath = mediaInput && !file.startsWith(mediaInput) && !file.startsWith('http')
+    ? `${mediaInput}/${normalizedFile}`
+    : file;
+
   return (
     <div className="absolute bottom-1 right-1 rounded-md bg-background/95 backdrop-blur-sm">
       <ButtonGroup>
@@ -59,7 +65,7 @@ const ImageTeaser = ({ file, config, onRemove }: {
           <TooltipTrigger asChild>
             <Button type="button" variant="ghost" size="icon-xs" asChild className="text-muted-foreground hover:text-foreground">
               <a
-                href={`https://github.com/${config.owner}/${config.repo}/blob/${config.branch}/${file}`}
+                href={`https://github.com/${config.owner}/${config.repo}/blob/${config.branch}/${githubPath}`}
                 target="_blank"
                 rel="noopener noreferrer"
                 aria-label="View image on GitHub"
@@ -92,11 +98,12 @@ const ImageTeaser = ({ file, config, onRemove }: {
   )
 };
 
-const SortableItem = ({ id, file, config, media, onRemove, readonly = false }: { 
+const SortableItem = ({ id, file, config, media, mediaInput, onRemove, readonly = false }: { 
   id: string;
   file: string;
   config: Pick<Config, "owner" | "repo" | "branch">;
   media: string;
+  mediaInput?: string;
   onRemove?: () => void;
   readonly?: boolean;
 }) => {
@@ -122,7 +129,7 @@ const SortableItem = ({ id, file, config, media, onRemove, readonly = false }: {
       <div title={file} className={readonly ? undefined : "cursor-move"} {...(!readonly ? attributes : {})} {...(!readonly ? listeners : {})}>
         <Thumbnail name={media} path={file} className="rounded-md w-28 h-28"/>
       </div>
-      <ImageTeaser file={file} config={config} onRemove={onRemove} />
+      <ImageTeaser file={file} config={config} mediaInput={mediaInput} onRemove={onRemove} />
     </div>
   );
 };
@@ -300,6 +307,7 @@ const EditComponent = forwardRef((props: EditorProps, ref: React.Ref<HTMLInputEl
                         file={file.path}
                         config={config}
                         media={mediaConfig.name}
+                        mediaInput={mediaConfig.input}
                         onRemove={isReadonly ? undefined : () => handleRemove(file.id)}
                         readonly={isReadonly}
                       />
@@ -312,7 +320,7 @@ const EditComponent = forwardRef((props: EditorProps, ref: React.Ref<HTMLInputEl
                 <div title={files[0].path}>
                   <Thumbnail name={mediaConfig.name} path={files[0].path} className="rounded-md w-28 h-28"/>
                 </div>
-                <ImageTeaser file={files[0].path} config={config} onRemove={isReadonly ? undefined : () => handleRemove(files[0].id)} />
+                <ImageTeaser file={files[0].path} config={config} mediaInput={mediaConfig.input} onRemove={isReadonly ? undefined : () => handleRemove(files[0].id)} />
               </div>
             )
           )}

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -240,6 +240,20 @@ const normalizeConfig = (configObject: any) => {
     delete configObjectCopy.navigation;
   }
 
+  if (Array.isArray(configObjectCopy.media) && Array.isArray(configObjectCopy.content)) {
+    configObjectCopy.media = configObjectCopy.media.map((mediaConfig: any) => {
+      if (mediaConfig.input == null || mediaConfig.input === "") {
+        const matchingContent = configObjectCopy.content.find(
+          (contentItem: any) => contentItem.name === mediaConfig.name
+        );
+        if (matchingContent?.path) {
+          mediaConfig.input = matchingContent.path.replace(/^\/|\/$/g, "");
+        }
+      }
+      return mediaConfig;
+    });
+  }
+
   return configObjectCopy;
 };
 


### PR DESCRIPTION
## Issue
This is [how my config looks like](https://github.com/Spr-Aachen/Twilight/blob/main/.pages.yml)
```yml
media:
  - name: posts
    input: src/content/posts
    output: /src/content/posts

content:
  - name: posts
    path: src/content/posts
    fields:
      - { name: cover, type: image, options: {media: posts} }
```
The media files in my project stored in the same folder as the markdown content, which is a common pattern in Astro.
However, when I write `cover: "./cover.jpg"` in frontmatter (relative to the markdown file), the `View on GitHub` link in the editor incorrectly points to `xxx/blob/main/cover.jpg` instead of `xxx/blob/main/src/content/posts/guide/cover.jpg`.

## Solution
Add `mediaInput` prop to `FileTeaser` and `ImageTeaser` components to handle relative media paths properly.
Comparing to the previous PR, this solution comes with minus changes to the code files.

I understand the documentation recommends to use a central folder, but many users prefer colocated media and it has been proved to [work with Decap CMS](https://github.com/Spr-Aachen/Twilight/blob/main/.decap.yml). So I still hope this could be supported.