### PR TITLE
Resolve the issue that the breadcrumb of new entry can't reflect accurate location if inside subfolders

### DIFF
--- a/components/entry/entry.tsx
+++ b/components/entry/entry.tsx
@@ -502,6 +502,19 @@ export function Entry({
     const rootLabel = schema.label || schema.name || name;
 
     if (!path) {
+      const rootPath = normalizePath(schema.path);
+      const parentPath = parent ? normalizePath(parent) : null;
+      const relativePath = parentPath ? getRelativePath(parentPath, rootPath) : null;
+      const segments = relativePath ? relativePath.split("/").filter(Boolean) : [];
+
+      const parentEntries = segments.map((segment, index) => ({
+        name: segment,
+        path: joinPathSegments([rootPath, segments.slice(0, index + 1).join("/")]),
+      }));
+
+      const immediateParent = parentEntries.length > 0 ? parentEntries[parentEntries.length - 1] : null;
+      const middleEntries = parentEntries.length > 1 ? parentEntries.slice(0, -1) : [];
+
       return (
         <>
           {groupTrail.map((group) => (
@@ -520,6 +533,43 @@ export function Entry({
             </BreadcrumbLink>
           </BreadcrumbItem>
           <BreadcrumbSeparator />
+
+          {middleEntries.length > 0 && (
+            <>
+              <BreadcrumbItem>
+                <DropdownMenu>
+                  <DropdownMenuTrigger className="flex items-center">
+                    <BreadcrumbEllipsis className="h-4 w-4" />
+                    <span className="sr-only">Show hidden segments</span>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="start">
+                    {middleEntries.map((entry) => (
+                      <DropdownMenuItem key={entry.path} asChild>
+                        <Link href={`/${config.owner}/${config.repo}/${encodeURIComponent(config.branch)}/collection/${encodeURIComponent(name)}?path=${encodeURIComponent(entry.path)}`}>
+                          {entry.name}
+                        </Link>
+                      </DropdownMenuItem>
+                    ))}
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </BreadcrumbItem>
+              <BreadcrumbSeparator />
+            </>
+          )}
+
+          {immediateParent && (
+            <>
+              <BreadcrumbItem>
+                <BreadcrumbLink asChild>
+                  <Link href={`/${config.owner}/${config.repo}/${encodeURIComponent(config.branch)}/collection/${encodeURIComponent(name)}?path=${encodeURIComponent(immediateParent.path)}`}>
+                    {immediateParent.name}
+                  </Link>
+                </BreadcrumbLink>
+              </BreadcrumbItem>
+              <BreadcrumbSeparator />
+            </>
+          )}
+
           <BreadcrumbItem className="truncate">
             <BreadcrumbPage className="font-semibold truncate">{displayTitle}</BreadcrumbPage>
           </BreadcrumbItem>
@@ -600,7 +650,7 @@ export function Entry({
         </BreadcrumbItem>
       </>
     );
-  }, [config.branch, config.owner, config.repo, displayTitle, name, path, schema, schemaType]);
+  }, [config.branch, config.owner, config.repo, displayTitle, name, path, parent, schema, schemaType]);
   const isCreationBlocked = !path && schemaType === "collection" && !canCreate;
   const showHeaderActions = error !== "Not found" && !isCreationBlocked;
   const headerActionsNode = useMemo(() => {


### PR DESCRIPTION
## Issue

When creating a new entry inside a subfolder of a collection e.g., "Posts > subfolder"
<img width="1920" height="1140" alt="2026-04-30 213520" src="https://github.com/user-attachments/assets/6e578b35-ae71-4062-8c6f-18714f363012" />

The breadcrumb path in the top bar incorrectly displays as "Posts > New entry" instead of "Posts > subfolder > New entry"
<img width="1920" height="1140" alt="2026-04-30 213527" src="https://github.com/user-attachments/assets/9696997e-ce07-47e5-8330-0f41aa5ae93d" />

Which means the subfolder segment was missing from the breadcrumb when `path` was null (i.e., during entry creation), even though the entry was correctly saved in the subfolder.

---

## Solution

When `path` is null but a parent directory is provided, the fix now:

1. Derives the relative path between the schema's root path and the parent directory
2. Splits it into segments and reconstructs intermediate folder entries
3. Renders the full breadcrumb chain: shows middle segments collapsed via a dropdown (with BreadcrumbEllipsis) if there are multiple levels, and always shows the immediate parent as a clickable link before the "New entry" page title
4. Adds parent to the `useMemo` dependency array to ensure the breadcrumb re-renders correctly when navigating between folders

This ensures the breadcrumb accurately reflects the actual location where the new entry will be created.
<img width="1920" height="1140" alt="586492702-d5dd1f9b-5574-4fd2-92f1-954217b282d6" src="https://github.com/user-attachments/assets/6e4ab29a-ccf9-4a33-9bd5-cf2a52c57c21" />