### PR TITLE
Refresh expired GitHub user access tokens

### DIFF
--- a/lib/token.ts
+++ b/lib/token.ts
@@ -12,11 +12,58 @@ import {
 } from "@/db/schema";
 import { eq } from "drizzle-orm";
 import { User } from "@/types/user";
+import { auth } from "@/lib/auth";
 import { getGithubAccount } from "@/lib/github-account";
 import { createHttpError } from "@/lib/api-error";
 import { collaboratorMatchesUserForRepo } from "@/lib/collaborator-access";
 
 const installationTokenRefreshInFlight = new Map<number, Promise<string>>();
+const userTokenRefreshInFlight = new Map<string, Promise<string | null>>();
+
+// Return a usable GitHub user access token, refreshing it via Better Auth when
+// the stored token is at/near expiry. GitHub App user tokens expire after 8
+// hours; without this the stored token simply dies and the user (including repo
+// owners) gets a misleading "no permission" error. Better Auth's getAccessToken
+// performs the refresh-token exchange and persists the rotated tokens. We
+// deduplicate concurrent refreshes per user because GitHub invalidates the old
+// refresh token the moment a new one is issued, so racing refreshes would
+// clobber each other's tokens.
+const getUserAccessToken = async (userId: string): Promise<string | null> => {
+  const githubAccount = await getGithubAccount(userId);
+  if (!githubAccount?.accessToken) return null;
+
+  // No recorded expiry means non-expiring tokens (expiring user tokens disabled
+  // on the GitHub App); use the stored token as-is.
+  if (!githubAccount.accessTokenExpiresAt) return githubAccount.accessToken;
+
+  const inFlight = userTokenRefreshInFlight.get(userId);
+  if (inFlight) return inFlight;
+
+  const refreshJob = (async () => {
+    try {
+      const { accessToken } = await auth.api.getAccessToken({
+        body: { providerId: "github", userId },
+      });
+      return accessToken ?? githubAccount.accessToken;
+    } catch (error) {
+      // Refresh failed (e.g. the refresh token was revoked). Fall back to the
+      // stored token so the caller surfaces a real auth error rather than
+      // masking it as a transient failure.
+      console.warn("[token] github user token refresh failed", {
+        userId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return githubAccount.accessToken;
+    }
+  })();
+
+  userTokenRefreshInFlight.set(userId, refreshJob);
+  try {
+    return await refreshJob;
+  } finally {
+    userTokenRefreshInFlight.delete(userId);
+  }
+};
 
 // Get a token for a user (including collagborators who need to provide an owner/repo scope).
 const getToken = cache(async (
@@ -25,11 +72,11 @@ const getToken = cache(async (
   repo: string,
   verifyGithubAccess: boolean = false,
 ) => {
-  const githubAccount = await getGithubAccount(user.id);
-  if (githubAccount?.accessToken) {
-    const hasGithubAccess = await canAccessRepoWithToken(githubAccount.accessToken, owner, repo);
+  const userAccessToken = await getUserAccessToken(user.id);
+  if (userAccessToken) {
+    const hasGithubAccess = await canAccessRepoWithToken(userAccessToken, owner, repo);
     if (hasGithubAccess) return {
-      token: githubAccount.accessToken,
+      token: userAccessToken,
       source: "user" as const,
     };
 
@@ -136,10 +183,10 @@ const getInstallationToken = cache(async (owner: string, repo: string) => {
 
 // Get the GitHub user token.
 const getUserToken = cache(async (userId: string) => {
-  const githubAccount = await getGithubAccount(userId);
-  if (!githubAccount?.accessToken) throw new Error(`GitHub token not found for user ${userId}.`);
+  const accessToken = await getUserAccessToken(userId);
+  if (!accessToken) throw new Error(`GitHub token not found for user ${userId}.`);
 
-  return githubAccount.accessToken;
+  return accessToken;
 });
 
 const canAccessRepoWithToken = async (


### PR DESCRIPTION
## Problem

GitHub App user access tokens expire after 8 hours (when "expiring user tokens" is enabled on the App, which it is on `app.pagescms.org`). Pages CMS reads the stored token straight from the `account` row and never refreshes it:

```ts
// lib/github-account.ts - a plain DB read, no expiry check, no refresh
const getGithubAccount = cache(async (userId) =>
  db.query.accountTable.findFirst({ where: ... providerId "github" }));
```

Better Auth stores `refresh_token` and `access_token_expires_at` on the account (`db/schema.ts`), but `getAccessToken()` is never called anywhere in the codebase, so the refresh token is never exercised outside of login.

Once the 8-hour token expires, `getToken()` in `lib/token.ts` degrades into a misleading permission error:

```ts
const githubAccount = await getGithubAccount(user.id);
if (githubAccount?.accessToken) {
  const hasGithubAccess = await canAccessRepoWithToken(githubAccount.accessToken, owner, repo);
  // expired token -> octokit 401 -> canAccessRepoWithToken swallows it -> false
  ...
}
// repo owner is not in collaboratorTable, so:
if (!permission) throw createHttpError(`You do not have permission to access "${owner}/${repo}".`, 403);
```

`canAccessRepoWithToken` catches the 401 and returns `false`, the owner has no `collaboratorTable` row to fall back on, and they get a 403 rendered as "you do not have permission to access this repository" (`app/(main)/[owner]/[repo]/layout.tsx`). The Better Auth **session** is still valid, so the app considers the user logged in and never re-runs the OAuth exchange that would mint a fresh token. Because the token lives in one account row shared across devices, the failure shows up on every device at once, and clearing it requires the session to expire or the user to manually revoke/re-auth.

## Fix

Route user-token reads through Better Auth's `getAccessToken`, which checks `accessTokenExpiresAt`, performs the refresh-token exchange via the provider's `refreshAccessToken` (the built-in GitHub provider implements it), and persists the rotated tokens back to the account row:

```ts
const { accessToken } = await auth.api.getAccessToken({
  body: { providerId: "github", userId },
});
```

Concurrent refreshes are deduplicated per user with an in-flight map, mirroring the existing `installationTokenRefreshInFlight` pattern. This matters because GitHub invalidates the old refresh token the instant a new one is issued - when an idle tab wakes and fires several API calls at once, racing refreshes would otherwise clobber each other's tokens and can corrupt the stored refresh token, which is the likely cause of the longer "can't log in on any device" lockouts (a broken refresh token plus retry loops tripping GitHub's secondary rate limits).

Accounts with no recorded expiry (non-expiring tokens, i.e. expiring user tokens disabled on the App) short-circuit and use the stored token as-is, so this is a no-op for those installs.

## Notes / testing

- `tsc --noEmit` and `eslint` pass.
- `getAccessToken` returns the decrypted token, matching how Pages CMS already passes the stored token directly to Octokit, so token encryption settings are unaffected.
- I could not run the full refresh path end-to-end against a live GitHub App with expiring tokens. Maintainer verification on `dev.pagescms.org` (let a user token cross its 8-hour expiry, confirm a subsequent edit refreshes instead of 403-ing) would be worthwhile before merge.

Targets `development` per `CONTRIBUTING.md`.
