### PR TITLE
Enable row level security at Supabase to quiet warnings

### DIFF
--- a/db/migrations/0013_enable_rls.sql
+++ b/db/migrations/0013_enable_rls.sql
@@ -1,0 +1,26 @@
+-- Enable Row Level Security on all public tables.
+-- The app connects via the postgres superuser (DATABASE_URL), which bypasses RLS,
+-- so no policies are needed. This blocks direct API access via the anon/authenticated roles.
+ALTER TABLE "user" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "account" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "session" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "verification" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "github_installation_token" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "collaborator" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "collaborator_invite" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "config" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "cache_file" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "cache_file_meta" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "cache_permission" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "action_run" ENABLE ROW LEVEL SECURITY;

--- a/db/migrations/meta/_journal.json
+++ b/db/migrations/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1778731770759,
       "tag": "0012_collaborator_invites",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1781654400000,
+      "tag": "0013_enable_rls",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
Once a week Supabase sends me a security warning email. This migration should make those stop.