### PR TITLE
fix: collection filename default ignores explicit format, causing ent…

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -268,7 +268,16 @@ const normalizeContentEntry = (
     }
   }
   if (item.filename == null && item.type === "collection") {
-    item.filename = "{year}-{month}-{day}-{primary}.md";
+    const formatExtensions: Record<string, string> = {
++      json: "json",
++      toml: "toml",
++      yaml: "yaml",
++      "json-frontmatter": "md",
++      "toml-frontmatter": "md",
++      "yaml-frontmatter": "md",
++    };
++    const ext = item.format != null ? formatExtensions[item.format] : undefined;
++    item.filename = `{year}-{month}-{day}-{primary}.${ext ?? "md"}`;
   }
   if (item.extension == null) {
     const filename = item.type === "file" ? item.path : item.filename;


### PR DESCRIPTION
…ries to disappear

When a collection sets format: json (or yaml/toml) but doesn't set filename, normalizeContentEntry in lib/config.ts still defaults filename to "{year}-{month}-{day}-{primary}.md", so extension resolves to "md" regardless of the declared format. The collection listing endpoint then filters out every file that doesn't end in .md, returning an empty entry list with no error — entries silently vanish from the CMS UI even though the files exist in the repo. Reproduced with a format: json collection containing only .json files. Fix: derive the default filename's extension from format when it's explicitly set.