### PR TITLE
fix: code field editor crashes when a field has no options (lintFn on undefined)

### DIFF
--- a/fields/core/code/edit-component.tsx
+++ b/fields/core/code/edit-component.tsx
@@ -55,7 +55,7 @@ const EditComponent = forwardRef((props: any, ref: any) => {
         break;
     }
 
-    if (field.options.lintFn) {
+    if (field.options?.lintFn) {
       exts.push(linter(field.options.lintFn));
     }
 


### PR DESCRIPTION
## Bug

Any user-configured `code` field **without an `options` block** crashes the entry editor (new or existing entry) with:

```
Something went wrong
Cannot read properties of undefined (reading 'lintFn')
```

Minimal repro `.pages.yml`:

```yaml
content:
  - name: essays
    type: collection
    path: src/content/essays
    fields:
      - name: body
        label: Body
        type: code   # no options block -> editor crashes
```

## Cause

`fields/core/code/edit-component.tsx` reads `field.options.lintFn` without optional chaining inside the extensions memo:

```ts
if (field.options.lintFn) {
```

The memo's own dependency array already guards with `field.options?.format` and `field.options?.lintFn`, and the internal callers (e.g. `components/entry/entry.tsx`) always pass an `options` object, so the crash only surfaces for repo configs that declare a bare `type: code` field. The config schema explicitly allows `options` to be absent (`options: z.object({}).optional().nullable()`), so a bare `type: code` is a valid config that the editor then crashes on.

## Fix

One character: `field.options?.lintFn`, aligning the guard with the surrounding code. Workaround for anyone hitting this today: add any `options` block (e.g. `options: { format: markdown }`) to the code field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)