### PR TITLE
Prevent 413 errors by optimizing large image uploads

### DIFF
--- a/components/media/media-upload.tsx
+++ b/components/media/media-upload.tsx
@@ -2,11 +2,12 @@
 
 import { useRef, cloneElement, useMemo, useCallback, createContext, useContext, useState } from "react";
 import { useConfig } from "@/contexts/config-context";
-import { getUploadFileName, joinPathSegments } from "@/lib/utils/file";
+import { getFileSize, getUploadFileName, joinPathSegments } from "@/lib/utils/file";
 import { toast } from "sonner";
 import { getSchemaByName } from "@/lib/schema";
 import { cn } from "@/lib/utils";
 import { requireApiSuccess } from "@/lib/api-client";
+import { prepareImageUpload } from "@/lib/utils/image-upload";
 import type { FileSaveData } from "@/types/api";
 
 interface MediaUploadContextValue {
@@ -49,29 +50,34 @@ function MediaUploadRoot({ children, path, onUpload, media, extensions, multiple
     [media, config.object]
   );
 
-  const accept = useMemo(() => {
-    if (!configMedia?.extensions && !extensions) return undefined;
-    
-    const allowedExtensions = extensions 
+  const allowedExtensions = useMemo(() => {
+    return extensions
       ? configMedia?.extensions
         ? extensions.filter(ext => configMedia.extensions.includes(ext))
         : extensions
       : configMedia?.extensions;
+  }, [extensions, configMedia?.extensions]);
+
+  const accept = useMemo(() => {
+    if (!allowedExtensions) return undefined;
 
     return allowedExtensions?.length > 0
       ? allowedExtensions.map((extension: string) => `.${extension}`).join(",")
       : undefined;
-  }, [extensions, configMedia?.extensions]);
+  }, [allowedExtensions]);
 
   const handleFiles = useCallback(async (files: File[]) => {
     try {
       for (const file of files) {
-        const uploadFilename = getUploadFileName(
-          file.name,
-          rename ?? configMedia?.rename,
-        );
-
         const uploadPromise = (async () => {
+          const preparedUpload = await prepareImageUpload(file, {
+            allowedExtensions,
+          });
+          const uploadFile = preparedUpload.file;
+          const uploadFilename = getUploadFileName(
+            uploadFile.name,
+            rename ?? configMedia?.rename,
+          );
           const content = await new Promise<string>((resolve, reject) => {
             const reader = new FileReader();
             reader.onload = () => {
@@ -79,7 +85,7 @@ function MediaUploadRoot({ children, path, onUpload, media, extensions, multiple
               resolve(base64Content);
             };
             reader.onerror = () => reject(new Error("Failed to read file"));
-            reader.readAsDataURL(file);
+            reader.readAsDataURL(uploadFile);
           });
 
           const fullPath = joinPathSegments([path ?? "", uploadFilename]);
@@ -98,13 +104,19 @@ function MediaUploadRoot({ children, path, onUpload, media, extensions, multiple
             "Failed to upload file",
           );
 
-          return data.data as FileSaveData;
+          return {
+            savedEntry: data.data as FileSaveData,
+            preparedUpload,
+          };
         })();
 
         await toast.promise(uploadPromise, {
-          loading: `Uploading ${file.name}`,
-          success: (savedEntry) => {
+          loading: `Preparing and uploading ${file.name}`,
+          success: ({ savedEntry, preparedUpload }) => {
             onUpload?.(savedEntry);
+            if (preparedUpload.optimized) {
+              return `Optimized and uploaded ${file.name} (${getFileSize(preparedUpload.originalSize)} → ${getFileSize(preparedUpload.finalSize)})`;
+            }
             return `Uploaded ${file.name}`;
           },
           error: (error: unknown) => error instanceof Error ? error.message : "Upload failed",
@@ -113,7 +125,7 @@ function MediaUploadRoot({ children, path, onUpload, media, extensions, multiple
     } catch (error) {
       console.error(error);
     }
-  }, [config, path, configMedia?.name, configMedia?.rename, onUpload, rename]);
+  }, [allowedExtensions, config, path, configMedia?.name, configMedia?.rename, onUpload, rename]);
 
   const contextValue = useMemo(() => ({
     handleFiles,

--- a/fields/core/rich-text/edit-component.tsx
+++ b/fields/core/rich-text/edit-component.tsx
@@ -38,6 +38,7 @@ import {
   normalizeMediaPath,
   normalizePath,
 } from "@/lib/utils/file";
+import { prepareImageUpload } from "@/lib/utils/image-upload";
 import type { ApiResponse, FileSaveData } from "@/types/api";
 import type { Field } from "@/types/field";
 import "./edit-component.css";
@@ -772,16 +773,20 @@ const EditComponent = forwardRef(
           );
         }
 
+        const preparedUpload = await prepareImageUpload(file, {
+          allowedExtensions,
+        });
+        const uploadFile = preparedUpload.file;
         const dataUrl = await new Promise<string>((resolve, reject) => {
           const reader = new FileReader();
           reader.onload = () => resolve(String(reader.result ?? ""));
           reader.onerror = () =>
             reject(new Error("Failed to read image file."));
-          reader.readAsDataURL(file);
+          reader.readAsDataURL(uploadFile);
         });
         const content = dataUrl.replace(/^(.+,)/, "");
         const uploadFilename = getUploadFileName(
-          file.name,
+          uploadFile.name,
           options.rename ?? mediaConfig.rename,
         );
         const targetPath = joinPathSegments([

--- a/lib/utils/image-upload.ts
+++ b/lib/utils/image-upload.ts
@@ -1,0 +1,261 @@
+import { getFileExtension, getFileSize } from "@/lib/utils/file";
+
+const MEBIBYTE = 1024 * 1024;
+
+const MAX_IMAGE_SOURCE_BYTES = 25 * MEBIBYTE;
+const SAFE_UPLOAD_BYTES = 3 * MEBIBYTE;
+const TARGET_IMAGE_BYTES = Math.floor(2.75 * MEBIBYTE);
+const MAX_IMAGE_DIMENSION = 2560;
+const MAX_COMPRESSION_ATTEMPTS = 8;
+const INITIAL_IMAGE_QUALITY = 0.82;
+const MIN_IMAGE_QUALITY = 0.58;
+
+type SupportedImageExtension = "jpg" | "jpeg" | "png" | "webp";
+
+type PreparedImageUpload = {
+  file: File;
+  optimized: boolean;
+  originalSize: number;
+  finalSize: number;
+};
+
+type PrepareImageUploadOptions = {
+  allowedExtensions?: string[];
+};
+
+type LoadedImage = {
+  source: CanvasImageSource;
+  width: number;
+  height: number;
+  cleanup: () => void;
+};
+
+const supportedImageExtensions = new Set<SupportedImageExtension>([
+  "jpg",
+  "jpeg",
+  "png",
+  "webp",
+]);
+
+const normalizeExtensions = (extensions?: string[]): Set<string> | null => {
+  if (!extensions?.length) return null;
+  return new Set(extensions.map((extension) => extension.toLowerCase()));
+};
+
+const replaceFileExtension = (filename: string, extension: string): string => {
+  const currentExtension = getFileExtension(filename);
+  const basename = currentExtension
+    ? filename.slice(0, -(currentExtension.length + 1))
+    : filename;
+  return `${basename}.${extension}`;
+};
+
+const loadImage = async (file: File): Promise<LoadedImage> => {
+  if (typeof createImageBitmap === "function") {
+    try {
+      const bitmap = await createImageBitmap(file, {
+        imageOrientation: "from-image",
+      });
+      return {
+        source: bitmap,
+        width: bitmap.width,
+        height: bitmap.height,
+        cleanup: () => bitmap.close(),
+      };
+    } catch {
+      // Fall back to an HTML image for browsers with partial ImageBitmap support.
+    }
+  }
+
+  const objectUrl = URL.createObjectURL(file);
+  const image = new Image();
+  image.decoding = "async";
+
+  try {
+    await new Promise<void>((resolve, reject) => {
+      image.onload = () => resolve();
+      image.onerror = () => reject(new Error("The browser could not decode this image."));
+      image.src = objectUrl;
+    });
+
+    return {
+      source: image,
+      width: image.naturalWidth,
+      height: image.naturalHeight,
+      cleanup: () => URL.revokeObjectURL(objectUrl),
+    };
+  } catch (error) {
+    URL.revokeObjectURL(objectUrl);
+    throw error;
+  }
+};
+
+const fitWithin = (
+  width: number,
+  height: number,
+  maxDimension: number,
+): { width: number; height: number } => {
+  const scale = Math.min(1, maxDimension / Math.max(width, height));
+  return {
+    width: Math.max(1, Math.round(width * scale)),
+    height: Math.max(1, Math.round(height * scale)),
+  };
+};
+
+const canvasToBlob = async (
+  canvas: HTMLCanvasElement,
+  type: string,
+  quality?: number,
+): Promise<Blob> => new Promise((resolve, reject) => {
+  canvas.toBlob(
+    (blob) => {
+      if (blob) {
+        resolve(blob);
+      } else {
+        reject(new Error("The browser could not encode this image."));
+      }
+    },
+    type,
+    quality,
+  );
+});
+
+const getOutputFormat = (
+  extension: SupportedImageExtension,
+  allowedExtensions: Set<string> | null,
+): { extension: SupportedImageExtension; type: string; lossy: boolean } => {
+  if (extension === "png" && (!allowedExtensions || allowedExtensions.has("webp"))) {
+    return { extension: "webp", type: "image/webp", lossy: true };
+  }
+  if (extension === "jpg" || extension === "jpeg") {
+    return { extension, type: "image/jpeg", lossy: true };
+  }
+  if (extension === "webp") {
+    return { extension, type: "image/webp", lossy: true };
+  }
+  return { extension: "png", type: "image/png", lossy: false };
+};
+
+const optimizeImage = async (
+  file: File,
+  extension: SupportedImageExtension,
+  allowedExtensions: Set<string> | null,
+): Promise<File> => {
+  const loadedImage = await loadImage(file);
+  const output = getOutputFormat(extension, allowedExtensions);
+  const canvas = document.createElement("canvas");
+  let maxDimension = Math.min(
+    MAX_IMAGE_DIMENSION,
+    Math.max(loadedImage.width, loadedImage.height),
+  );
+  let quality = INITIAL_IMAGE_QUALITY;
+  let smallestBlob: Blob | null = null;
+
+  try {
+    for (let attempt = 0; attempt < MAX_COMPRESSION_ATTEMPTS; attempt += 1) {
+      const dimensions = fitWithin(
+        loadedImage.width,
+        loadedImage.height,
+        maxDimension,
+      );
+      canvas.width = dimensions.width;
+      canvas.height = dimensions.height;
+
+      const context = canvas.getContext("2d", { alpha: true });
+      if (!context) throw new Error("The browser could not prepare an image canvas.");
+
+      context.drawImage(
+        loadedImage.source,
+        0,
+        0,
+        dimensions.width,
+        dimensions.height,
+      );
+
+      const blob = await canvasToBlob(
+        canvas,
+        output.type,
+        output.lossy ? quality : undefined,
+      );
+      smallestBlob = !smallestBlob || blob.size < smallestBlob.size
+        ? blob
+        : smallestBlob;
+
+      if (blob.size <= TARGET_IMAGE_BYTES) {
+        const actualExtension = blob.type === "image/webp"
+          ? "webp"
+          : blob.type === "image/png"
+            ? "png"
+            : output.extension;
+        if (allowedExtensions && !allowedExtensions.has(actualExtension)) {
+          throw new Error(
+            `This browser encoded ${file.name} as .${actualExtension}, which is not allowed by the media configuration.`,
+          );
+        }
+        return new File(
+          [blob],
+          replaceFileExtension(file.name, actualExtension),
+          { type: blob.type || output.type, lastModified: file.lastModified },
+        );
+      }
+
+      const estimatedScale = Math.sqrt(TARGET_IMAGE_BYTES / blob.size) * 0.92;
+      const nextScale = Math.min(0.88, Math.max(0.65, estimatedScale));
+      maxDimension = Math.max(640, Math.floor(maxDimension * nextScale));
+      if (output.lossy) {
+        quality = Math.max(MIN_IMAGE_QUALITY, quality - 0.04);
+      }
+    }
+  } finally {
+    canvas.width = 0;
+    canvas.height = 0;
+    loadedImage.cleanup();
+  }
+
+  throw new Error(
+    `Could not reduce ${file.name} below ${getFileSize(TARGET_IMAGE_BYTES)}. ` +
+    `The smallest result was ${getFileSize(smallestBlob?.size ?? file.size)}.`,
+  );
+};
+
+const prepareImageUpload = async (
+  file: File,
+  options: PrepareImageUploadOptions = {},
+): Promise<PreparedImageUpload> => {
+  const originalSize = file.size;
+
+  if (originalSize <= SAFE_UPLOAD_BYTES) {
+    return { file, optimized: false, originalSize, finalSize: originalSize };
+  }
+
+  if (originalSize > MAX_IMAGE_SOURCE_BYTES) {
+    throw new Error(
+      `${file.name} is ${getFileSize(originalSize)}. ` +
+      `Pages CMS can automatically optimize images up to ${getFileSize(MAX_IMAGE_SOURCE_BYTES)}.`,
+    );
+  }
+
+  const extension = getFileExtension(file.name).toLowerCase();
+  if (!supportedImageExtensions.has(extension as SupportedImageExtension)) {
+    throw new Error(
+      `${file.name} is too large to upload safely (${getFileSize(originalSize)}). ` +
+      `Automatic optimization supports JPG, PNG, and WebP; reduce other files below ${getFileSize(SAFE_UPLOAD_BYTES)} before uploading.`,
+    );
+  }
+
+  const allowedExtensions = normalizeExtensions(options.allowedExtensions);
+  const optimizedFile = await optimizeImage(
+    file,
+    extension as SupportedImageExtension,
+    allowedExtensions,
+  );
+
+  return {
+    file: optimizedFile,
+    optimized: true,
+    originalSize,
+    finalSize: optimizedFile.size,
+  };
+};
+
+export { prepareImageUpload };


### PR DESCRIPTION
## Summary

- optimize JPG, JPEG, PNG, and WebP files in the browser before media uploads
- apply the same upload preparation to the media library/image fields and rich-text image uploads
- keep files at or below 3 MiB unchanged, optimize larger images up to 25 MiB, and reject unsupported oversized files with a clear message
- preserve configured media extensions; large PNG files use WebP only when WebP is allowed
- report the original and optimized sizes after a successful media upload

## Problem

The hosted Pages CMS app runs on Vercel, where Function request bodies are limited to 4.5 MB. Media uploads are Base64-encoded and wrapped in JSON, increasing their request size by roughly one third. As a result, normal phone photos can fail with `413 FUNCTION_PAYLOAD_TOO_LARGE` before the Pages CMS route can handle the request.

Vercel documents the limit here: https://vercel.com/docs/functions/limitations#request-body-size

## Behavior

- files at or below 3 MiB remain byte-for-byte unchanged
- larger supported images are resized to at most 2560 px on the longest edge and encoded to a target below 2.75 MiB
- transparent PNG images retain transparency when converted to WebP
- image orientation is applied while decoding, and browser resources are released after processing
- source images above 25 MiB are rejected before decoding
- oversized GIF, SVG, document, and other unsupported files receive an actionable error instead of an opaque 413 response

Large images stored in the repository are the optimized versions rather than the original camera files. Existing smaller uploads are unaffected.

## Validation

- `tsc --noEmit`
- `npm run lint` (0 errors; existing repository warnings remain)
- `next build`
- real-browser checks:
  - 10 MiB JPEG → 2.45 MiB JPEG
  - 20 MiB JPEG → 2.46 MiB JPEG
  - 8.43 MiB transparent PNG → 1.7 MiB WebP with transparency preserved
  - small JPEG remained unchanged
  - 26 MiB JPEG was rejected with the configured limit message
  - no browser console errors

This is a draft to get maintainer feedback on the size thresholds and whether the optimization policy should become configurable.
